### PR TITLE
shlo_ref add more tensor utility functions

### DIFF
--- a/tensorflow/lite/experimental/shlo/BUILD
+++ b/tensorflow/lite/experimental/shlo/BUILD
@@ -48,6 +48,7 @@ cc_test(
     deps = [
         ":data_type",
         ":tensor",
+        ":tensor_with_data",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/lite/experimental/shlo/tensor.h
+++ b/tensorflow/lite/experimental/shlo/tensor.h
@@ -67,7 +67,8 @@ struct Tensor {
 
   size_t Rank() const;
   DataType StorageType() const;
-
+  DataType ExpressedType() const;
+  
   DimensionSize NumElements() const;
   size_t SizeInBytes() const;
 
@@ -102,6 +103,28 @@ struct Tensor {
     return absl::MakeConstSpan(GetDataAs<data_type>(),
                                static_cast<size_t>(NumElements()));
   }
+
+  template <DataType storage_type,
+            typename T = typename Storage<storage_type>::Type>
+  T Get(absl::Span<const DimensionSize> indices) const {
+    return GetDataAs<storage_type>()[FlattenIndex(indices)];
+  }
+
+  template <DataType storage_type,
+            typename T = typename Storage<storage_type>::Type>
+  void Set(absl::Span<const DimensionSize> indices, T element) {
+    T* tensor_data = GetDataAs<storage_type>();
+    tensor_data[FlattenIndex(indices)] = element;
+    return;
+  }
+
+  bool IsInBounds(absl::Span<const DimensionSize> indices) const;
+
+  DimensionSize FlattenIndex(absl::Span<const DimensionSize> indices) const;
+
+  void GetNdIndex(
+      DimensionSize index,
+      absl::InlinedVector<DimensionSize, kMaxNumDimensions>& indices) const;
 
   TensorTypeVariant type;
 

--- a/tensorflow/lite/experimental/shlo/tensor_test.cc
+++ b/tensorflow/lite/experimental/shlo/tensor_test.cc
@@ -15,8 +15,14 @@ limitations under the License.
 
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "tensorflow/lite/experimental/shlo/data_type.h"
+#include "tensorflow/lite/experimental/shlo/tensor_with_data.h"
+
+using testing::Eq;
+using testing::Pointwise;
 
 namespace shlo_ref {
 namespace {
@@ -30,6 +36,57 @@ TEST(TensorTest, BaselineTypeWorks) {
   EXPECT_EQ(BaselineType(DataType::kBF16), DataType::kBF16);
   EXPECT_EQ(BaselineType(DataType::kF16), DataType::kF16);
   EXPECT_EQ(BaselineType(DataType::kF32), DataType::kF32);
+}
+
+// Tensor::GetNdIndex
+TEST(TensorTest, GetNdIndexWorks) {
+  const Shape shape({1, 3, 3});
+  std::vector<int32_t> data{5, 7, 9, 5, 4, 9, 7, 9, 8};
+
+  Tensor tensor{
+      .type = TensorType{.shape = shape, .element_type = DataType::kSI32},
+      .data = data.data()};
+
+  DimensionSize index = 5;
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> indices(tensor.Rank());
+  tensor.GetNdIndex(index, indices);
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> expected_indices = {
+      0, 1, 2};
+
+  EXPECT_THAT(indices, Pointwise(Eq(), expected_indices));
+}
+
+// Tensor::FlattenIndex
+TEST(TensorTest, FlattenIndexWorks) {
+  const Shape shape({1, 3, 3});
+  std::vector<int32_t> data{5, 7, 9, 5, 4, 9, 7, 9, 8};
+
+  Tensor tensor{
+      .type = TensorType{.shape = shape, .element_type = DataType::kSI32},
+      .data = data.data()};
+
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> indices = {0, 1, 2};
+  DimensionSize index_value = tensor.FlattenIndex(indices);
+  DimensionSize expected_index_value = 5;
+
+  EXPECT_THAT(expected_index_value, index_value);
+}
+
+// Tensor::Get and Tensor::Set
+TEST(TensorTest, TensorGetSetWorks) {
+  const Shape shape({1, 3, 3});
+  std::vector<int32_t> data{3, 7, 9, 3, 4, 9, 7, 9, 8};
+
+  Tensor tensor{
+      .type = TensorType{.shape = shape, .element_type = DataType::kSI32},
+      .data = data.data()};
+
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> indices = {0, 1, 2};
+  tensor.Set<DataType::kSI32>(indices, 5);
+  int32_t element = tensor.Get<DataType::kSI32>(indices);
+  DimensionSize expected_element = 5;
+
+  EXPECT_THAT(expected_element, element);
 }
 
 }  // namespace


### PR DESCRIPTION
- Adds Tensor::Get and Tensor::Set
- Adds Tensor::ExpressedType
- Adds Tensor::GetNdIndex and Tensor::FlattenIndex