### PR TITLE
Shlo_ref add dot_general op basic version

### DIFF
--- a/tensorflow/lite/experimental/shlo/BUILD
+++ b/tensorflow/lite/experimental/shlo/BUILD
@@ -48,6 +48,7 @@ cc_test(
     deps = [
         ":data_type",
         ":tensor",
+        ":tensor_with_data",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/tensorflow/lite/experimental/shlo/ops/BUILD
+++ b/tensorflow/lite/experimental/shlo/ops/BUILD
@@ -287,6 +287,40 @@ cc_test(
     ],
 )
 
+
+cc_library(
+    name = "dot_general",
+    srcs = ["dot_general.cc"],
+    hdrs = ["dot_general.h"],
+    deps = [
+        ":util",
+        "//tensorflow/lite/experimental/shlo:data_type",
+        "//tensorflow/lite/experimental/shlo:dispatch",
+        "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:quantize",
+        "//tensorflow/lite/experimental/shlo:tensor",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_test(
+    name = "dot_general_test",
+    srcs = ["dot_general_test.cc"],
+    linkopts = shlo_ref_linkopts(),
+    deps = [
+        ":dot_general",
+        ":test_util",
+        "//tensorflow/lite/experimental/shlo:data_type",
+        "//tensorflow/lite/experimental/shlo:shape",
+        "//tensorflow/lite/experimental/shlo:status_matcher",
+        "//tensorflow/lite/experimental/shlo:tensor",
+        "//tensorflow/lite/experimental/shlo:tensor_matcher",
+        "//tensorflow/lite/experimental/shlo:tensor_with_data",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "sine",
     srcs = ["sine.cc"],

--- a/tensorflow/lite/experimental/shlo/ops/dot_general.cc
+++ b/tensorflow/lite/experimental/shlo/ops/dot_general.cc
@@ -1,0 +1,152 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/experimental/shlo/ops/dot_general.h"
+
+#include "tensorflow/lite/experimental/shlo/data_type.h"
+#include "tensorflow/lite/experimental/shlo/dispatch.h"
+#include "tensorflow/lite/experimental/shlo/shape.h"
+
+namespace shlo_ref {
+
+bool ContainsDimension(absl::Span<const Axis> dimensions, Axis dimension) {
+  return std::find(dimensions.begin(), dimensions.end(), dimension) !=
+         dimensions.end();
+}
+
+absl::InlinedVector<Axis, kMaxNumDimensions> CalculateResultDimensions(
+    Axis rank, absl::Span<const Axis> batching_dimensions,
+    absl::Span<const Axis> contracting_dimensions) {
+  absl::InlinedVector<Axis, kMaxNumDimensions> result_dims;
+  for (Axis i = 0; i < rank; ++i) {
+    if (!ContainsDimension(batching_dimensions, i) &&
+        !ContainsDimension(contracting_dimensions, i)) {
+      result_dims.push_back(i);
+    }
+  }
+  return result_dims;
+}
+
+bool IncrementIndices(
+    const Tensor& lhs,
+    absl::InlinedVector<DimensionSize, kMaxNumDimensions>& lhs_index,
+    absl::InlinedVector<DimensionSize, kMaxNumDimensions>& rhs_index,
+    absl::Span<const Axis> lhs_contracting_dimensions,
+    absl::Span<const Axis> rhs_contracting_dimensions, const size_t lhsc_size) {
+  if (lhsc_size == 0) {
+    return false;
+  }
+  for (int64_t i = static_cast<int64_t>(lhsc_size) - 1; i >= 0; --i) {
+    lhs_index[lhs_contracting_dimensions[i]]++;
+    rhs_index[rhs_contracting_dimensions[i]]++;
+    if (lhs_index[lhs_contracting_dimensions[i]] <
+        lhs.shape().Dim(lhs_contracting_dimensions[i])) {
+      return true;
+    }
+    if (i == 0) {
+      return false;
+    }
+    lhs_index[lhs_contracting_dimensions[i]] = 0;
+    rhs_index[rhs_contracting_dimensions[i]] = 0;
+  }
+  return true;
+}
+
+template <DataType storage_type>
+absl::Status EvaluateImpl(DotGeneralOp& op, const Tensor& lhs,
+                          const Tensor& rhs,
+                          absl::Span<const Axis> lhs_batching_dimensions,
+                          absl::Span<const Axis> rhs_batching_dimensions,
+                          absl::Span<const Axis> lhs_contracting_dimensions,
+                          absl::Span<const Axis> rhs_contracting_dimensions,
+                          Tensor& output) {
+  using StorageT = StorageType<storage_type>;
+  StorageT* output_data = output.GetDataAs<storage_type>();
+  const DimensionSize output_size = output.NumElements();
+  const Axis lhs_rank = lhs.Rank();
+  const Axis rhs_rank = rhs.Rank();
+  const Axis output_rank = output.Rank();
+  const size_t lhsb_size = lhs_batching_dimensions.size();
+  const size_t lhsc_size = lhs_contracting_dimensions.size();
+  const size_t lhsr_size = op.lhs_result_dims.size();
+  const size_t rhsr_size = op.rhs_result_dims.size();
+
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> lhs_index(lhs_rank);
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> rhs_index(rhs_rank);
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> output_index(
+      output_rank);
+
+  StorageT output_element(0);
+  for (DimensionSize k = 0; k < output_size; ++k, ++output_data) {
+    output.GetNdIndex(k, output_index);
+    absl::c_fill(lhs_index, 0);
+    absl::c_fill(rhs_index, 0);
+
+    Axis result_dim = 0;
+    for (size_t i = 0; i < lhsb_size; ++i, ++result_dim) {
+      lhs_index[lhs_batching_dimensions[i]] = output_index[result_dim];
+      rhs_index[rhs_batching_dimensions[i]] = output_index[result_dim];
+    }
+    for (size_t i = 0; i < lhsr_size; ++i, ++result_dim) {
+      lhs_index[op.lhs_result_dims[i]] = output_index[result_dim];
+    }
+    for (size_t i = 0; i < rhsr_size; ++i, ++result_dim) {
+      rhs_index[op.rhs_result_dims[i]] = output_index[result_dim];
+    }
+    output_element = 0;
+    while (true) {
+      output_element +=
+          lhs.Get<storage_type>(lhs_index) * rhs.Get<storage_type>(rhs_index);
+      if (!IncrementIndices(lhs, lhs_index, rhs_index,
+                            lhs_contracting_dimensions,
+                            rhs_contracting_dimensions, lhsc_size)) {
+        break;
+      }
+    }
+    *output_data = output_element;
+  }
+  return absl::OkStatus();
+}
+
+DotGeneralOp Create(DotGeneralOp::Attributes attributes) {
+  return {.attributes = attributes};
+}
+
+absl::Status Prepare(DotGeneralOp& op, const Tensor& lhs, const Tensor& rhs,
+                     Tensor& output) {
+  const Axis lhs_rank = lhs.Rank();
+  const Axis rhs_rank = rhs.Rank();
+  op.lhs_result_dims =
+      CalculateResultDimensions(lhs_rank, op.attributes.lhs_batching_dimensions,
+                                op.attributes.lhs_contracting_dimensions);
+  op.rhs_result_dims =
+      CalculateResultDimensions(rhs_rank, op.attributes.rhs_batching_dimensions,
+                                op.attributes.rhs_contracting_dimensions);
+
+  return absl::OkStatus();
+}
+
+absl::Status Evaluate(DotGeneralOp& op, const Tensor& lhs, const Tensor& rhs,
+                      Tensor& output) {
+  DISPATCH_BOOL_INT_FLOAT(EvaluateImpl, output.tensor_element_type(), op, lhs,
+                          rhs, op.attributes.lhs_batching_dimensions,
+                          op.attributes.rhs_batching_dimensions,
+                          op.attributes.lhs_contracting_dimensions,
+                          op.attributes.rhs_contracting_dimensions, output);
+  return absl::FailedPreconditionError(
+      "stablehlo.dot_general: Unsupported tensor type.");
+}
+
+}  // namespace shlo_ref

--- a/tensorflow/lite/experimental/shlo/ops/dot_general.h
+++ b/tensorflow/lite/experimental/shlo/ops/dot_general.h
@@ -1,0 +1,52 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_DOT_GENERAL_H_
+#define TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_DOT_GENERAL_H_
+
+#include "absl/status/status.h"
+#include "tensorflow/lite/experimental/shlo/tensor.h"
+
+namespace shlo_ref {
+
+enum class PrecisionTypes {
+  DEFAULT,
+  HIGH,
+  HIGHEST,
+};
+
+class DotGeneralOp {
+ public:
+  struct Attributes {
+    absl::Span<const Axis> lhs_batching_dimensions;
+    absl::Span<const Axis> rhs_batching_dimensions;
+    absl::Span<const Axis> lhs_contracting_dimensions;
+    absl::Span<const Axis> rhs_contracting_dimensions;
+    std::array<PrecisionTypes, 2> precision_configs;
+  };
+  Attributes attributes;
+  absl::InlinedVector<Axis, kMaxNumDimensions> lhs_result_dims;
+  absl::InlinedVector<Axis, kMaxNumDimensions> rhs_result_dims;
+};
+
+DotGeneralOp Create(DotGeneralOp::Attributes attributes);
+absl::Status Prepare(DotGeneralOp& op, const Tensor& lhs, const Tensor& rhs,
+                     Tensor& output);
+absl::Status Evaluate(DotGeneralOp& op, const Tensor& lhs, const Tensor& rhs,
+                      Tensor& output);
+
+}  // namespace shlo_ref
+
+#endif  // TENSORFLOW_LITE_EXPERIMENTAL_SHLO_OPS_DOT_GENERAL_H_

--- a/tensorflow/lite/experimental/shlo/ops/dot_general_test.cc
+++ b/tensorflow/lite/experimental/shlo/ops/dot_general_test.cc
@@ -1,0 +1,199 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/experimental/shlo/ops/dot_general.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "tensorflow/lite/experimental/shlo/ops/test_util.h"
+#include "tensorflow/lite/experimental/shlo/shape.h"
+#include "tensorflow/lite/experimental/shlo/status_matcher.h"
+
+using testing::Eq;
+using testing::FloatEq;
+using testing::FloatNear;
+using testing::Pointwise;
+
+namespace shlo_ref {
+
+namespace {
+template <class T>
+struct NonQuantizedIntDotGeneralTest : ::testing::Test {};
+TYPED_TEST_SUITE(NonQuantizedIntDotGeneralTest, IntTestTypes, TestParamNames);
+
+TYPED_TEST(NonQuantizedIntDotGeneralTest, IntTestTypesTensorsWork1) {
+  using StorageT = typename TypeParam::StorageT;
+  const Shape shape_lhs({7, 3, 4});
+  const Shape shape_rhs({7, 4});
+  const Shape shape_r({7, 3});
+
+  Vector<int64_t> lhs_data_int{
+      0,  1,  4,  1,  -2, -3, 0, 0, 6,  -1, 0,  0,  1,  0,  -2, 0,  1,
+      3,  4,  -6, 2,  4,  4,  0, 0, -2, -1, 1,  -2, -3, 0,  2,  -3, 0,
+      0,  -2, 4,  -7, 2,  2,  0, 4, 2,  0,  -6, 1,  1,  2,  -2, -2, 0,
+      -1, -4, -1, 0,  -1, 1,  3, 1, 1,  -4, 0,  0,  1,  -1, 0,  4,  -2,
+      0,  5,  0,  -1, 0,  2,  1, 2, -1, 1,  -3, -2, -6, -3, -1, -3};
+  Vector<StorageT> lhs_data(lhs_data_int.begin(), lhs_data_int.end());
+  Vector<int64_t> rhs_data_int{2,  0, -1, 4,  -4, 0,  2,  -1, 0, 6,
+                               8,  0, -1, -3, -1, -1, -3, 0,  5, 0,
+                               -3, 0, 3,  -1, 2,  1,  -2, -3};
+  Vector<StorageT> rhs_data(rhs_data_int.begin(), rhs_data_int.end());
+  Vector<StorageT> output_data(shape_r.NumElements());
+  Vector<Axis> lhsb_dim{0};
+  Vector<Axis> rhsb_dim{0};
+  Vector<Axis> lhsc_dim{2};
+  Vector<Axis> rhsc_dim{1};
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  Tensor output_tensor{
+      .type = TensorType{.shape = shape_r, .element_type = TypeParam::kStorage},
+      .data = output_data.data()};
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op =
+      Create(DotGeneralOp::Attributes{.lhs_batching_dimensions = lhsb_dim,
+                                      .rhs_batching_dimensions = rhsb_dim,
+                                      .lhs_contracting_dimensions = lhsc_dim,
+                                      .rhs_contracting_dimensions = rhsc_dim,
+                                      .precision_configs = precision_configs});
+
+  Vector<int64_t> expected_data_int{0,   -4, 12, -8,  10, 0,  -20,
+                                    -18, 0,  13, -14, 0,  6,  12,
+                                    2,   11, 17, 1,   -6, 11, -4};
+  Vector<StorageT> expected_data(expected_data_int.begin(),
+                                 expected_data_int.end());
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(Eq(), expected_data));
+}
+
+using kF32TestTypes = ::testing::Types<TestParam<DataType::kF32>>;
+template <class T>
+struct NonQuantizedkF32DotGeneralTest : ::testing::Test {};
+TYPED_TEST_SUITE(NonQuantizedkF32DotGeneralTest, kF32TestTypes, TestParamNames);
+
+TYPED_TEST(NonQuantizedkF32DotGeneralTest, kF32TestTypesTensorsWork1) {
+  using StorageT = typename TypeParam::StorageT;
+
+  const Shape shape_lhs({4, 3});
+  const Shape shape_rhs({3, 6});
+  const Shape shape_r({4, 6});
+
+  Vector<StorageT> lhs_data{5.81311798,  2.08485532,  0.151162371, -1.21007407,
+                            -1.59476554, 0.846119463, -0.83784312, -0.416278511,
+                            1.24929118,  3.46354723,  2.21915126,  3.81866336};
+  Vector<StorageT> rhs_data{
+      -2.10215521, -1.803730e+00, -7.83739519, 4.36787844,   1.4788357,
+      3.10357666,  -4.46420813,   0.879630148, -2.18081808,  -1.95115197,
+      -3.56435633, -0.671983778,  -2.76886797, -0.212248296, 2.77085519,
+      -1.21441388, -3.28464937,   -4.60568237};
+  Vector<StorageT> output_data(shape_r.NumElements());
+  Vector<Axis> lhsb_dim{};
+  Vector<Axis> rhsb_dim{};
+  Vector<Axis> lhsc_dim{1};
+  Vector<Axis> rhsc_dim{0};
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  Tensor output_tensor{
+      .type = TensorType{.shape = shape_r, .element_type = TypeParam::kStorage},
+      .data = output_data.data()};
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op =
+      Create(DotGeneralOp::Attributes{.lhs_batching_dimensions = lhsb_dim,
+                                      .rhs_batching_dimensions = rhsb_dim,
+                                      .lhs_contracting_dimensions = lhsc_dim,
+                                      .rhs_contracting_dimensions = rhsc_dim,
+                                      .precision_configs = precision_configs});
+
+  Vector<StorageT> expected_data = {
+      -21.9458523, -8.6834774,  -49.6875458, 21.1395512,   0.668963671,
+      15.9442625,  7.32033587,  0.600255728, 15.3061972,   -3.20136595,
+      1.11560607,  -6.58085871, 0.160507768, 0.87991172,   10.9359407,
+      -4.36453056, -3.85875082, -8.07441616, -27.7610416,  -5.10577631,
+      -21.4037914, 6.1610136,   -15.3307991, -8.329400e+00};
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(FloatNear(1e-5), expected_data));
+}
+
+using kF16TestTypes = ::testing::Types<TestParam<DataType::kF16>>;
+template <class T>
+struct NonQuantizedkF16DotGeneralTest : ::testing::Test {};
+TYPED_TEST_SUITE(NonQuantizedkF16DotGeneralTest, kF16TestTypes, TestParamNames);
+
+TYPED_TEST(NonQuantizedkF16DotGeneralTest, kF16TestTypesTensorsWork1) {
+  using StorageT = typename TypeParam::StorageT;
+
+  const Shape shape_lhs({2, 2, 2});
+  const Shape shape_rhs({2, 2, 2});
+  const Shape shape_r({2, 2, 2});
+
+  Vector<float> lhs_data_float{1.1, 2.2, 3.3, 4.3, 5.5, 6, 7, 8};
+  Vector<StorageT> lhs_data(lhs_data_float.begin(), lhs_data_float.end());
+  Vector<float> rhs_data_float{1.2, 0, 0, 1.2, 1.2, 0, 0, 1.2};
+  Vector<StorageT> rhs_data(rhs_data_float.begin(), rhs_data_float.end());
+  Vector<StorageT> output_data(shape_r.NumElements());
+  Vector<Axis> lhsb_dim{0};
+  Vector<Axis> rhsb_dim{0};
+  Vector<Axis> lhsc_dim{2};
+  Vector<Axis> rhsc_dim{2};
+
+  Tensor lhs{.type = TensorType{.shape = shape_lhs,
+                                .element_type = TypeParam::kStorage},
+             .data = lhs_data.data()};
+  Tensor rhs{.type = TensorType{.shape = shape_rhs,
+                                .element_type = TypeParam::kStorage},
+             .data = rhs_data.data()};
+  Tensor output_tensor{
+      .type = TensorType{.shape = shape_r, .element_type = TypeParam::kStorage},
+      .data = output_data.data()};
+  std::array<PrecisionTypes, 2> precision_configs = {PrecisionTypes::DEFAULT,
+                                                     PrecisionTypes::DEFAULT};
+
+  auto op =
+      Create(DotGeneralOp::Attributes{.lhs_batching_dimensions = lhsb_dim,
+                                      .rhs_batching_dimensions = rhsb_dim,
+                                      .lhs_contracting_dimensions = lhsc_dim,
+                                      .rhs_contracting_dimensions = rhsc_dim,
+                                      .precision_configs = precision_configs});
+
+  Vector<StorageT> expected_data;
+  Vector<float> expected_data_float = {1.31934, 2.63867, 3.96094, 5.16016,
+                                       6.60156, 7.20312, 8.39844, 9.60156};
+  expected_data.assign(expected_data_float.begin(), expected_data_float.end());
+
+  ASSERT_OK(Prepare(op, lhs, rhs, output_tensor));
+  ASSERT_OK(Evaluate(op, lhs, rhs, output_tensor));
+  EXPECT_THAT(output_data, Pointwise(FloatEq(), expected_data));
+}
+
+}  // namespace
+}  // namespace shlo_ref

--- a/tensorflow/lite/experimental/shlo/tensor.h
+++ b/tensorflow/lite/experimental/shlo/tensor.h
@@ -67,7 +67,8 @@ struct Tensor {
 
   size_t Rank() const;
   DataType StorageType() const;
-
+  DataType ExpressedType() const;
+  
   DimensionSize NumElements() const;
   size_t SizeInBytes() const;
 
@@ -102,6 +103,28 @@ struct Tensor {
     return absl::MakeConstSpan(GetDataAs<data_type>(),
                                static_cast<size_t>(NumElements()));
   }
+
+  template <DataType storage_type,
+            typename T = typename Storage<storage_type>::Type>
+  T Get(absl::Span<const DimensionSize> indices) const {
+    return GetDataAs<storage_type>()[FlattenIndex(indices)];
+  }
+
+  template <DataType storage_type,
+            typename T = typename Storage<storage_type>::Type>
+  void Set(absl::Span<const DimensionSize> indices, T element) {
+    T* tensor_data = GetDataAs<storage_type>();
+    tensor_data[FlattenIndex(indices)] = element;
+    return;
+  }
+
+  bool IsInBounds(absl::Span<const DimensionSize> indices) const;
+
+  DimensionSize FlattenIndex(absl::Span<const DimensionSize> indices) const;
+
+  void GetNdIndex(
+      DimensionSize index,
+      absl::InlinedVector<DimensionSize, kMaxNumDimensions>& indices) const;
 
   TensorTypeVariant type;
 

--- a/tensorflow/lite/experimental/shlo/tensor_test.cc
+++ b/tensorflow/lite/experimental/shlo/tensor_test.cc
@@ -15,8 +15,14 @@ limitations under the License.
 
 #include "tensorflow/lite/experimental/shlo/tensor.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include "tensorflow/lite/experimental/shlo/data_type.h"
+#include "tensorflow/lite/experimental/shlo/tensor_with_data.h"
+
+using testing::Eq;
+using testing::Pointwise;
 
 namespace shlo_ref {
 namespace {
@@ -30,6 +36,57 @@ TEST(TensorTest, BaselineTypeWorks) {
   EXPECT_EQ(BaselineType(DataType::kBF16), DataType::kBF16);
   EXPECT_EQ(BaselineType(DataType::kF16), DataType::kF16);
   EXPECT_EQ(BaselineType(DataType::kF32), DataType::kF32);
+}
+
+// Tensor::GetNdIndex
+TEST(TensorTest, GetNdIndexWorks) {
+  const Shape shape({1, 3, 3});
+  std::vector<int32_t> data{5, 7, 9, 5, 4, 9, 7, 9, 8};
+
+  Tensor tensor{
+      .type = TensorType{.shape = shape, .element_type = DataType::kSI32},
+      .data = data.data()};
+
+  DimensionSize index = 5;
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> indices(tensor.Rank());
+  tensor.GetNdIndex(index, indices);
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> expected_indices = {
+      0, 1, 2};
+
+  EXPECT_THAT(indices, Pointwise(Eq(), expected_indices));
+}
+
+// Tensor::FlattenIndex
+TEST(TensorTest, FlattenIndexWorks) {
+  const Shape shape({1, 3, 3});
+  std::vector<int32_t> data{5, 7, 9, 5, 4, 9, 7, 9, 8};
+
+  Tensor tensor{
+      .type = TensorType{.shape = shape, .element_type = DataType::kSI32},
+      .data = data.data()};
+
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> indices = {0, 1, 2};
+  DimensionSize index_value = tensor.FlattenIndex(indices);
+  DimensionSize expected_index_value = 5;
+
+  EXPECT_THAT(expected_index_value, index_value);
+}
+
+// Tensor::Get and Tensor::Set
+TEST(TensorTest, TensorGetSetWorks) {
+  const Shape shape({1, 3, 3});
+  std::vector<int32_t> data{3, 7, 9, 3, 4, 9, 7, 9, 8};
+
+  Tensor tensor{
+      .type = TensorType{.shape = shape, .element_type = DataType::kSI32},
+      .data = data.data()};
+
+  absl::InlinedVector<DimensionSize, kMaxNumDimensions> indices = {0, 1, 2};
+  tensor.Set<DataType::kSI32>(indices, 5);
+  int32_t element = tensor.Get<DataType::kSI32>(indices);
+  DimensionSize expected_element = 5;
+
+  EXPECT_THAT(expected_element, element);
 }
 
 }  // namespace


### PR DESCRIPTION
- Adds reference implementation of dot_general op
- Adds support for non-quantized types
- Adds unit test for Integer types, kF32, and kF16 type