### PR TITLE
TfLite Stablehlo add dot_general op basic version

### DIFF
--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include <memory>
 
 #include "flatbuffers/flatbuffers.h"  // from @flatbuffers
-#include "flatbuffers/vector.h"  // from @flatbuffers
+#include "flatbuffers/vector.h"       // from @flatbuffers
 #include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/core/c/builtin_op_data.h"
 #include "tensorflow/lite/core/c/common.h"
@@ -925,6 +925,10 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
       return ParseStablehloComposite(op, error_reporter, allocator,
                                      builtin_data);
     }
+    case BuiltinOperator_STABLEHLO_DOT_GENERAL: {
+      return ParseStablehloDotGeneral(op, error_reporter, allocator,
+                                      builtin_data);
+    }
     // TODO: skip param parsing for now since ops below don't have kernels
     case BuiltinOperator_STABLEHLO_SLICE:
     case BuiltinOperator_STABLEHLO_BROADCAST_IN_DIM:
@@ -959,7 +963,6 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
     case BuiltinOperator_STABLEHLO_IOTA:
     case BuiltinOperator_STABLEHLO_COMPARE:
     case BuiltinOperator_STABLEHLO_CONVERT:
-    case BuiltinOperator_STABLEHLO_DOT_GENERAL:
     case BuiltinOperator_STABLEHLO_SORT:
     case BuiltinOperator_STABLEHLO_WHILE:
     case BuiltinOperator_STABLEHLO_TRANSPOSE:
@@ -2272,6 +2275,66 @@ TfLiteStatus ParseStablehloRngBitGenerator(const Operator* op,
     // better understand the ramifications of changing the legacy behavior.
   }
 
+  *builtin_data = params.release();
+  return kTfLiteOk;
+}
+
+TfLiteStatus ParseStablehloDotGeneral(const Operator* op,
+                                      ErrorReporter* error_reporter,
+                                      BuiltinDataAllocator* allocator,
+                                      void** builtin_data) {
+  CheckParsePointerParams(op, error_reporter, allocator, builtin_data);
+
+  SafeBuiltinDataAllocator safe_allocator(allocator);
+  auto params = safe_allocator.Allocate<TfLiteStablehloDotGeneralParams>();
+  const StablehloDotGeneralOptions* schema_params =
+      op->builtin_options_2_as_StablehloDotGeneralOptions();
+
+  if (!schema_params) {
+    TF_LITE_REPORT_ERROR(
+        error_reporter,
+        "Could not get 'stablehlo.dot_general' operation parameters.");
+    return kTfLiteError;
+  }
+  auto LoadAttr =
+      [&error_reporter](
+          int64_t* params_array, const size_t params_array_size_bytes,
+          const flatbuffers::Vector<int64_t>* const flatbuffer_vector,
+          const char* const attr_name) -> TfLiteStatus {
+    TfLiteStatus status = FlatBufferIntVectorToArray(
+        params_array_size_bytes, flatbuffer_vector, params_array,
+        error_reporter, "stablehlo.dot_general");
+    if (status != kTfLiteOk) {
+      TF_LITE_REPORT_ERROR(error_reporter, "Check the '%s' attribute.",
+                           attr_name);
+    }
+    return status;
+  };
+
+  TF_LITE_ENSURE_STATUS(LoadAttr(
+      params->lhs_batching_dimensions, sizeof(params->lhs_batching_dimensions),
+      schema_params->lhs_batching_dimensions(), "lhs_batching_dimensions"));
+  TF_LITE_ENSURE_STATUS(LoadAttr(
+      params->rhs_batching_dimensions, sizeof(params->rhs_batching_dimensions),
+      schema_params->rhs_batching_dimensions(), "rhs_batching_dimensions"));
+  TF_LITE_ENSURE_STATUS(LoadAttr(params->lhs_contracting_dimensions,
+                                 sizeof(params->lhs_contracting_dimensions),
+                                 schema_params->lhs_contracting_dimensions(),
+                                 "lhs_contracting_dimensions"));
+  TF_LITE_ENSURE_STATUS(LoadAttr(params->rhs_contracting_dimensions,
+                                 sizeof(params->rhs_contracting_dimensions),
+                                 schema_params->rhs_contracting_dimensions(),
+                                 "rhs_contracting_dimensions"));
+
+  params->num_precision_configs = schema_params->precision_config()->size();
+  params->num_lhs_batching_dimensions =
+      schema_params->lhs_batching_dimensions()->size();
+  params->num_rhs_batching_dimensions =
+      schema_params->rhs_batching_dimensions()->size();
+  params->num_lhs_contracting_dimensions =
+      schema_params->lhs_contracting_dimensions()->size();
+  params->num_rhs_contracting_dimensions =
+      schema_params->rhs_contracting_dimensions()->size();
   *builtin_data = params.release();
   return kTfLiteOk;
 }

--- a/tensorflow/lite/core/api/flatbuffer_conversions.h
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.h
@@ -450,6 +450,11 @@ TfLiteStatus ParseStablehloComposite(const Operator* op,
                                      BuiltinDataAllocator* allocator,
                                      void** builtin_data);
 
+TfLiteStatus ParseStablehloDotGeneral(const Operator* op,
+                                      ErrorReporter* error_reporter,
+                                      BuiltinDataAllocator* allocator,
+                                      void** builtin_data);
+
 }  // namespace tflite
 
 #endif  // TENSORFLOW_LITE_CORE_API_FLATBUFFER_CONVERSIONS_H_

--- a/tensorflow/lite/core/c/builtin_op_data.h
+++ b/tensorflow/lite/core/c/builtin_op_data.h
@@ -37,6 +37,7 @@ extern "C" {
 #define TFLITE_STABLEHLO_GATHER_PARAMS_MAX_DIMENSION_COUNT 8
 #define TFLITE_STABLEHLO_REDUCE_WINDOW_PARAMS_MAX_DIMENSION_COUNT 8
 #define TFLITE_STABLEHLO_PAD_PARAMS_MAX_DIMENSION_COUNT 8
+#define TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT 6
 
 // TODO(aselle): Consider using "if this then that" for testing.
 
@@ -591,6 +592,26 @@ typedef enum {
 typedef struct {
   TfLiteRngAlgorithm algorithm;
 } TfLiteStablehloRngBitGeneratorParams;
+
+typedef struct {
+  // See the stablehlo spec for the explanation of the attributes:
+  // https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dot_general
+  int64_t lhs_batching_dimensions
+      [TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT];
+  int num_lhs_batching_dimensions;
+  int64_t rhs_batching_dimensions
+      [TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT];
+  int num_rhs_batching_dimensions;
+  int64_t lhs_contracting_dimensions
+      [TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT];
+  int num_lhs_contracting_dimensions;
+  int64_t rhs_contracting_dimensions
+      [TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT];
+  int num_rhs_contracting_dimensions;
+  int num_precision_configs;
+  uint32_t
+      precision_config[TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT];
+} TfLiteStablehloDotGeneralParams;
 
 typedef struct {
   // See the stablehlo spec for the explanation of the attributes:

--- a/tensorflow/lite/core/c/builtin_op_data.h
+++ b/tensorflow/lite/core/c/builtin_op_data.h
@@ -610,7 +610,7 @@ typedef struct {
   int num_rhs_contracting_dimensions;
   int num_precision_configs;
   uint32_t
-      precision_config[TFLITE_STABLEHLO_DOT_GENERAL_PARAMS_MAX_DIMENSION_COUNT];
+      precision_config[2];
 } TfLiteStablehloDotGeneralParams;
 
 typedef struct {

--- a/tensorflow/lite/core/kernels/builtin_op_kernels.h
+++ b/tensorflow/lite/core/kernels/builtin_op_kernels.h
@@ -297,9 +297,7 @@ TfLiteRegistration* Register_STABLEHLO_PAD();
 TfLiteRegistration*
 Register_STABLEHLO_IOTA();  // WARNING: not implemented, using this
                             // op will crash the runtime
-TfLiteRegistration*
-Register_STABLEHLO_DOT_GENERAL();  // WARNING: not implemented, using this
-                                   // op will crash the runtime
+TfLiteRegistration* Register_STABLEHLO_DOT_GENERAL();
 
 TfLiteRegistration* Register_STABLEHLO_REDUCE_WINDOW();
 

--- a/tensorflow/lite/core/kernels/register.cc
+++ b/tensorflow/lite/core/kernels/register.cc
@@ -385,6 +385,8 @@ BuiltinOpResolver::BuiltinOpResolver() {
   AddBuiltin(BuiltinOperator_STABLEHLO_PAD, Register_STABLEHLO_PAD());
   AddBuiltin(BuiltinOperator_STABLEHLO_COMPOSITE,
              Register_STABLEHLO_COMPOSITE());
+  AddBuiltin(BuiltinOperator_STABLEHLO_DOT_GENERAL,
+             Register_STABLEHLO_DOT_GENERAL());
   AddCustom("NumericVerify", tflite::ops::custom::Register_NUMERIC_VERIFY());
   // TODO(andrewharp, ahentz): Move these somewhere more appropriate so that
   // custom ops aren't always included by default.

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -888,7 +888,6 @@ cc_library(
         ":variable_op_kernels",
         "@fft2d",
         "@ruy//ruy/profiler:instrumentation",
-        "//tensorflow/core/platform:bfloat16",
         "//tensorflow/lite/c:c_api_types",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite:array",

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -767,6 +767,7 @@ BUILTIN_KERNEL_SRCS = [
     "stablehlo_gather.cc",
     "stablehlo_add.cc",
     "stablehlo_composite.cc",
+    "stablehlo_dot_general.cc",
     "stablehlo_multiply.cc",
     "stablehlo_pad.cc",
     "stablehlo_reduce_window.cc",
@@ -887,6 +888,7 @@ cc_library(
         ":variable_op_kernels",
         "@fft2d",
         "@ruy//ruy/profiler:instrumentation",
+        "//tensorflow/core/platform:bfloat16",
         "//tensorflow/lite/c:c_api_types",
         "//tensorflow/lite/c:common",
         "//tensorflow/lite:array",
@@ -3233,6 +3235,20 @@ cc_test(
         "//tensorflow/lite/core/c:common",
         "//tensorflow/lite/schema:schema_fbs",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "stablehlo_dot_general_test",
+    size = "small",
+    srcs = ["stablehlo_dot_general_test.cc"],
+    deps = [
+        ":test_main",
+        ":test_util",
+        "//tensorflow/lite/c:c_api_types",
+        "//tensorflow/lite/core/c:common",
+        "//tensorflow/lite/schema:schema_fbs",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/tensorflow/lite/kernels/stablehlo_dot_general.cc
+++ b/tensorflow/lite/kernels/stablehlo_dot_general.cc
@@ -1,0 +1,192 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <vector>
+
+#include "Eigen/Core"  // from @eigen_archive
+#include "tensorflow/lite/core/c/builtin_op_data.h"
+#include "tensorflow/lite/core/c/c_api_types.h"
+#include "tensorflow/lite/core/c/common.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+#include "tensorflow/lite/kernels/tensor_slice_util.h"
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace stablehlo_dot_general {
+namespace {
+
+using TfLiteIntArrayUniquePtr =
+    std::unique_ptr<TfLiteIntArray, decltype(&TfLiteIntArrayFree)>;
+
+constexpr int kLhsTensor = 0;
+constexpr int kRhsTensor = 1;
+constexpr int kOutputTensor = 0;
+
+static std::vector<int64_t> CalculateResultDimensions(
+    const int rank, const int64_t* batching_dimensions,
+    const int batching_array_size, const int64_t* contracting_dimensions,
+    const int contracting_array_size) {
+  std::vector<int64_t> result_dims;
+  for (int64_t i = 0; i < rank; ++i) {
+    if (!ArrayContains(batching_dimensions, batching_array_size, i) &&
+        !ArrayContains(contracting_dimensions, contracting_array_size, i)) {
+      result_dims.push_back(i);
+    }
+  }
+  return result_dims;
+}
+
+static TfLiteIntArrayUniquePtr GetResultShape(
+    const TfLiteStablehloDotGeneralParams* params, const TfLiteTensor* lhs,
+    const TfLiteTensor* rhs) {
+  const int lhs_rank = lhs->dims->size;
+  const int rhs_rank = rhs->dims->size;
+  const int lhsb_size = params->num_lhs_batching_dimensions;
+  const int rhsb_size = params->num_rhs_batching_dimensions;
+  const int lhsc_size = params->num_lhs_contracting_dimensions;
+  const int rhsc_size = params->num_rhs_contracting_dimensions;
+
+  std::vector<int64_t> lhs_result_dims = CalculateResultDimensions(
+      lhs_rank, params->lhs_batching_dimensions, lhsb_size,
+      params->lhs_contracting_dimensions, lhsc_size);
+  std::vector<int64_t> rhs_result_dims = CalculateResultDimensions(
+      rhs_rank, params->rhs_batching_dimensions, rhsb_size,
+      params->rhs_contracting_dimensions, rhsc_size);
+  int result_rank = lhsb_size + lhs_result_dims.size() + rhs_result_dims.size();
+  TfLiteIntArrayUniquePtr result = TfLiteIntArrayUniquePtr(
+      TfLiteIntArrayCreate(result_rank), &TfLiteIntArrayFree);
+  // output shape calculation
+  for (int i = 0; i < lhsb_size; ++i) {
+    result->data[i] = lhs->dims->data[params->lhs_batching_dimensions[i]];
+  }
+  for (int i = 0; i < lhs_result_dims.size(); ++i) {
+    result->data[i + lhsb_size] = lhs->dims->data[lhs_result_dims[i]];
+  }
+  for (int i = 0; i < rhs_result_dims.size(); ++i) {
+    result->data[i + lhsb_size + lhs_result_dims.size()] =
+        rhs->dims->data[rhs_result_dims[i]];
+  }
+  return result;
+}
+
+template <typename DataType>
+TfLiteStatus EvalImpl(const TfLiteTensor* lhs, const TfLiteTensor* rhs,
+                      TfLiteTensor* output) {
+  const DataType* lhs_data = GetTensorData<DataType>(lhs);
+  const DataType* rhs_data = GetTensorData<DataType>(rhs);
+  DataType* output_data = GetTensorData<DataType>(output);
+
+  const int batch_size = lhs->dims->data[0];
+  const int n = lhs->dims->data[1];
+  const int p = lhs->dims->data[2];
+  const int m = rhs->dims->data[1];
+  const int output_batch_size = n * m;
+  const int lhs_batch_size = n * p;
+  const int rhs_batch_size = m * p;
+
+  using EigenMatrixMapRowMajorConst =
+      Eigen::Map<const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic,
+                                     Eigen::RowMajor>>;
+  using EigenMatrixMapColMajorConst =
+      Eigen::Map<const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic,
+                                     Eigen::ColMajor>>;
+  using EigenMatrixMapRowMajorMutable = Eigen::Map<
+      Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
+  for (int batch = 0; batch < batch_size; ++batch) {
+    EigenMatrixMapRowMajorConst eigen_lhs(lhs_data + batch * lhs_batch_size, n,
+                                          p);
+    EigenMatrixMapColMajorConst eigen_rhs(rhs_data + batch * rhs_batch_size, p,
+                                          m);
+    EigenMatrixMapRowMajorMutable eigen_dst(
+        output_data + batch * output_batch_size, n, m);
+    if (m == 1) {
+      eigen_dst.col(0).noalias() = eigen_lhs * eigen_rhs.col(0);
+    } else if (n == 1) {
+      eigen_dst.row(0).noalias() = eigen_lhs.row(0) * eigen_rhs;
+    } else {
+      eigen_dst.noalias() = eigen_lhs * eigen_rhs;
+    }
+  }
+  return TfLiteStatus::kTfLiteOk;
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 2);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
+
+  const TfLiteTensor* lhs;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kLhsTensor, &lhs));
+  const TfLiteTensor* rhs;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kRhsTensor, &rhs));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  const TfLiteStablehloDotGeneralParams* params =
+      reinterpret_cast<TfLiteStablehloDotGeneralParams*>(node->builtin_data);
+  TfLiteIntArrayUniquePtr result_shape = GetResultShape(params, lhs, rhs);
+  TF_LITE_ENSURE_STATUS(
+      context->ResizeTensor(context, output, result_shape.release()));
+  return TfLiteStatus::kTfLiteOk;
+}
+
+}  // namespace
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteTensor* lhs;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kLhsTensor, &lhs));
+  const TfLiteTensor* rhs;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kRhsTensor, &rhs));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+
+  TfLiteType data_type = lhs->type;
+  if (data_type == kTfLiteInt8) {
+    return EvalImpl<int8_t>(lhs, rhs, output);
+  } else if (data_type == kTfLiteBFloat16) {
+    return EvalImpl<Eigen::bfloat16>(lhs, rhs, output);
+  } else if (data_type == kTfLiteFloat16) {
+    return EvalImpl<Eigen::half>(lhs, rhs, output);
+  } else if (data_type == kTfLiteFloat32) {
+    return EvalImpl<float>(lhs, rhs, output);
+  } else if (data_type == kTfLiteInt16) {
+    return EvalImpl<int16_t>(lhs, rhs, output);
+  } else if (data_type == kTfLiteInt32) {
+    return EvalImpl<int32_t>(lhs, rhs, output);
+  } else {
+    TF_LITE_KERNEL_LOG(context, "(DataType: %s) currently not supported.\n",
+                       TfLiteTypeGetName(data_type));
+    return TfLiteStatus::kTfLiteError;
+  }
+}
+
+}  // namespace stablehlo_dot_general
+
+TfLiteRegistration* Register_STABLEHLO_DOT_GENERAL() {
+  static TfLiteRegistration r = {/*.init=*/nullptr,
+                                 /*.free=*/nullptr,
+                                 /*.prepare=*/stablehlo_dot_general::Prepare,
+                                 /*.invoke=*/stablehlo_dot_general::Eval};
+  return &r;
+}
+
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/kernels/stablehlo_dot_general_test.cc
+++ b/tensorflow/lite/kernels/stablehlo_dot_general_test.cc
@@ -1,0 +1,207 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <initializer_list>
+#include <vector>
+
+#include "tensorflow/lite/c/c_api_types.h"
+#include "tensorflow/lite/core/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+namespace tflite {
+namespace {
+
+using testing::FloatEq;
+using testing::FloatNear;
+using testing::Pointwise;
+
+class StablehloDotGeneralOpModel : public SingleOpModel {
+ public:
+  StablehloDotGeneralOpModel(const TensorData& lhs, const TensorData& rhs,
+                             const TensorData& output,
+                             const TfLiteStablehloDotGeneralParams& params) {
+    lhs_ = AddInput(lhs);
+    rhs_ = AddInput(rhs);
+    output_ = AddOutput(output);
+    SetBuiltinOp(
+        BuiltinOperator_STABLEHLO_DOT_GENERAL,
+        BuiltinOptions2_StablehloDotGeneralOptions,
+        CreateStablehloDotGeneralOptions(
+            builder_,
+            builder_.CreateVector(
+                std::vector(params.lhs_batching_dimensions,
+                            params.lhs_batching_dimensions +
+                                params.num_lhs_batching_dimensions)),
+            builder_.CreateVector(
+                std::vector(params.rhs_batching_dimensions,
+                            params.rhs_batching_dimensions +
+                                params.num_rhs_batching_dimensions)),
+            builder_.CreateVector(
+                std::vector(params.lhs_contracting_dimensions,
+                            params.lhs_contracting_dimensions +
+                                params.num_lhs_contracting_dimensions)),
+            builder_.CreateVector(
+                std::vector(params.rhs_contracting_dimensions,
+                            params.rhs_contracting_dimensions +
+                                params.num_rhs_contracting_dimensions)),
+            builder_.CreateVector(std::vector(
+                params.precision_config,
+                params.precision_config + params.num_precision_configs)))
+            .Union());
+    BuildInterpreter({GetShape(lhs_), GetShape(rhs_)});
+  }
+
+  template <typename T>
+  void SetInputs(std::initializer_list<T> data_lhs,
+                 std::initializer_list<T> data_rhs) {
+    PopulateTensor<T>(lhs_, data_lhs);
+    PopulateTensor<T>(rhs_, data_rhs);
+  }
+  template <typename T>
+  std::vector<T> GetOutput() {
+    return ExtractVector<T>(output_);
+  }
+
+ protected:
+  int lhs_;
+  int rhs_;
+  int output_;
+};
+
+template <>
+void StablehloDotGeneralOpModel::SetInputs<Eigen::half>(
+    std::initializer_list<Eigen::half> data_lhs,
+    std::initializer_list<Eigen::half> data_rhs) {
+  PopulateTensor<Eigen::half>(lhs_, data_lhs);
+  PopulateTensor<Eigen::half>(rhs_, data_rhs);
+}
+template <>
+void StablehloDotGeneralOpModel::SetInputs<Eigen::bfloat16>(
+    std::initializer_list<Eigen::bfloat16> data_lhs,
+    std::initializer_list<Eigen::bfloat16> data_rhs) {
+  PopulateTensor<Eigen::bfloat16>(lhs_, data_lhs);
+  PopulateTensor<Eigen::bfloat16>(rhs_, data_rhs);
+}
+
+TEST(StablehloDotGeneralModelTest, F32TestWorks1) {
+  TfLiteStablehloDotGeneralParams params = {
+      {0},  // lhs_batching_dimensions;
+      1,    // num_lhs_batching_dimensions
+      {0},  // rhs_batching_dimensions;
+      1,    // num_rhs_batching_dimensions
+      {2},  // lhs_contracting_dimensions;
+      1,    // num_lhs_contracting_dimensions
+      {2},  // rhs_contracting_dimensions;
+      1,    // num_rhs_contracting_dimensions
+      2,    // num_precision_configs
+      {tflite::StablehloPrecisionConfig::StablehloPrecisionConfig_DEFAULT,
+       tflite::StablehloPrecisionConfig::
+           StablehloPrecisionConfig_DEFAULT}  // precision config;
+  };
+  StablehloDotGeneralOpModel model({TensorType_FLOAT32, {2, 2, 2}},
+                                   {TensorType_FLOAT32, {2, 2, 2}},
+                                   {TensorType_FLOAT32, {}}, params);
+
+  model.SetInputs<float>({1.1, 2.2, 3.3, 4.3, 5.5, 6.0, 7.0, 8.0},
+                         {1.2, 0.0, 0.0, 1.2, 1.2, 0.0, 0.0, 1.2});
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  std::vector<float> expected_values = {1.32, 2.64, 3.96, 5.16,
+                                        6.6,  7.2,  8.4,  9.6};
+  EXPECT_THAT(model.GetOutput<float>(), Pointwise(FloatEq(), expected_values));
+}
+
+TEST(StablehloDotGeneralModelTest, F16TestWorks1) {
+  TfLiteStablehloDotGeneralParams params = {
+      {0},  // lhs_batching_dimensions;
+      1,    // num_lhs_batching_dimensions
+      {0},  // rhs_batching_dimensions;
+      1,    // num_rhs_batching_dimensions
+      {2},  // lhs_contracting_dimensions;
+      1,    // num_lhs_contracting_dimensions
+      {2},  // rhs_contracting_dimensions;
+      1,    // num_rhs_contracting_dimensions
+      2,    // num_precision_configs
+      {tflite::StablehloPrecisionConfig::StablehloPrecisionConfig_DEFAULT,
+       tflite::StablehloPrecisionConfig::
+           StablehloPrecisionConfig_DEFAULT}  // precision config;
+  };
+  StablehloDotGeneralOpModel model({TensorType_FLOAT16, {2, 2, 2}},
+                                   {TensorType_FLOAT16, {2, 2, 2}},
+                                   {TensorType_FLOAT16, {}}, params);
+
+  std::initializer_list<Eigen::half> lhs_data{
+      Eigen::half(1.1), Eigen::half(2.2), Eigen::half(3.3), Eigen::half(4.3),
+      Eigen::half(5.5), Eigen::half(6.0), Eigen::half(7.0), Eigen::half(8.0)};
+  std::initializer_list<Eigen::half> rhs_data{
+      Eigen::half(1.2), Eigen::half(0.0), Eigen::half(0.0), Eigen::half(1.2),
+      Eigen::half(1.2), Eigen::half(0.0), Eigen::half(0.0), Eigen::half(1.2)};
+  model.SetInputs<Eigen::half>(lhs_data, rhs_data);
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  std::initializer_list<Eigen::half> expected_values{
+      Eigen::half(1.31934), Eigen::half(2.6386), Eigen::half(3.9609),
+      Eigen::half(5.1601),  Eigen::half(6.6015), Eigen::half(7.2031),
+      Eigen::half(8.3984),  Eigen::half(9.6015)};
+  EXPECT_THAT(model.GetOutput<Eigen::half>(),
+              Pointwise(FloatNear(1e-5), expected_values));
+}
+
+TEST(StablehloDotGeneralModelTest, BFloat16Works1) {
+  TfLiteStablehloDotGeneralParams params = {
+      {0},  // lhs_batching_dimensions;
+      1,    // num_lhs_batching_dimensions
+      {0},  // rhs_batching_dimensions;
+      1,    // num_rhs_batching_dimensions
+      {2},  // lhs_contracting_dimensions;
+      1,    // num_lhs_contracting_dimensions
+      {2},  // rhs_contracting_dimensions;
+      1,    // num_rhs_contracting_dimensions
+      2,    // num_precision_configs
+      {tflite::StablehloPrecisionConfig::StablehloPrecisionConfig_DEFAULT,
+       tflite::StablehloPrecisionConfig::
+           StablehloPrecisionConfig_DEFAULT}  // precision config;
+  };
+  StablehloDotGeneralOpModel model({TensorType_BFLOAT16, {2, 2, 2}},
+                                   {TensorType_BFLOAT16, {2, 2, 2}},
+                                   {TensorType_BFLOAT16, {}}, params);
+
+  std::initializer_list<Eigen::bfloat16> lhs_data{
+      Eigen::bfloat16(1.1), Eigen::bfloat16(2.2), Eigen::bfloat16(3.3),
+      Eigen::bfloat16(4.3), Eigen::bfloat16(5.5), Eigen::bfloat16(6.0),
+      Eigen::bfloat16(7.0), Eigen::bfloat16(8.0)};
+  std::initializer_list<Eigen::bfloat16> rhs_data{
+      Eigen::bfloat16(1.2), Eigen::bfloat16(0.0), Eigen::bfloat16(0.0),
+      Eigen::bfloat16(1.2), Eigen::bfloat16(1.2), Eigen::bfloat16(0.0),
+      Eigen::bfloat16(0.0), Eigen::bfloat16(1.2)};
+  model.SetInputs<Eigen::bfloat16>(lhs_data, rhs_data);
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  std::initializer_list<Eigen::bfloat16> expected_values = {
+      Eigen::bfloat16(1.32813), Eigen::bfloat16(2.6562),
+      Eigen::bfloat16(3.96875), Eigen::bfloat16(5.1875),
+      Eigen::bfloat16(6.6250),  Eigen::bfloat16(7.21875),
+      Eigen::bfloat16(8.4375),  Eigen::bfloat16(9.6250)};
+  EXPECT_THAT(model.GetOutput<Eigen::bfloat16>(),
+              Pointwise(FloatNear(1e-5), expected_values));
+}
+
+}  // namespace
+}  // namespace tflite

--- a/tensorflow/lite/kernels/stablehlo_dot_general_test.cc
+++ b/tensorflow/lite/kernels/stablehlo_dot_general_test.cc
@@ -85,22 +85,7 @@ class StablehloDotGeneralOpModel : public SingleOpModel {
   int output_;
 };
 
-template <>
-void StablehloDotGeneralOpModel::SetInputs<Eigen::half>(
-    std::initializer_list<Eigen::half> data_lhs,
-    std::initializer_list<Eigen::half> data_rhs) {
-  PopulateTensor<Eigen::half>(lhs_, data_lhs);
-  PopulateTensor<Eigen::half>(rhs_, data_rhs);
-}
-template <>
-void StablehloDotGeneralOpModel::SetInputs<Eigen::bfloat16>(
-    std::initializer_list<Eigen::bfloat16> data_lhs,
-    std::initializer_list<Eigen::bfloat16> data_rhs) {
-  PopulateTensor<Eigen::bfloat16>(lhs_, data_lhs);
-  PopulateTensor<Eigen::bfloat16>(rhs_, data_rhs);
-}
-
-TEST(StablehloDotGeneralModelTest, F32TestWorks1) {
+TEST(StablehloDotGeneralModelTest, DotGeneralFloat32) {
   TfLiteStablehloDotGeneralParams params = {
       {0},  // lhs_batching_dimensions;
       1,    // num_lhs_batching_dimensions
@@ -128,7 +113,7 @@ TEST(StablehloDotGeneralModelTest, F32TestWorks1) {
   EXPECT_THAT(model.GetOutput<float>(), Pointwise(FloatEq(), expected_values));
 }
 
-TEST(StablehloDotGeneralModelTest, F16TestWorks1) {
+TEST(StablehloDotGeneralModelTest, DotGeneralFloat16) {
   TfLiteStablehloDotGeneralParams params = {
       {0},  // lhs_batching_dimensions;
       1,    // num_lhs_batching_dimensions
@@ -164,7 +149,7 @@ TEST(StablehloDotGeneralModelTest, F16TestWorks1) {
               Pointwise(FloatNear(1e-5), expected_values));
 }
 
-TEST(StablehloDotGeneralModelTest, BFloat16Works1) {
+TEST(StablehloDotGeneralModelTest, DotGeneralBFloat16) {
   TfLiteStablehloDotGeneralParams params = {
       {0},  // lhs_batching_dimensions;
       1,    // num_lhs_batching_dimensions

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
- Adds Eigen Implementation of dot_general op, supporting 3d input (batch 2d matric)
- Adds unit test for F32, BF16 and F16.