### PR TITLE
Tflite range missing datatypes support

### DIFF
--- a/tensorflow/lite/kernels/range.cc
+++ b/tensorflow/lite/kernels/range.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <functional>
 #include <type_traits>
 
+#include "Eigen/Core"
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/internal/reference/reference_ops.h"
 #include "tensorflow/lite/kernels/internal/tensor.h"
@@ -43,15 +44,62 @@ struct OpData {
 };
 
 template <typename T>
+float dequantize_value(const TfLiteTensor* input) {
+  const T quantized_input_value = *GetTensorData<T>(input);
+  int32_t zero_point = input->params.zero_point;
+  const double scale = input->params.scale;
+  return (scale * (quantized_input_value - zero_point));
+}
+
+template <typename T>
+T quantize_value(const float value, const double scale, int32_t zero_point) {
+  static constexpr int32_t min_val = std::numeric_limits<T>::min();
+  static constexpr int32_t max_val = std::numeric_limits<T>::max();
+
+  int32_t unclamped =
+      static_cast<int32_t>(TfLiteRound(value / static_cast<float>(scale))) +
+      zero_point;
+  int32_t clamped = std::min(std::max(unclamped, min_val), max_val);
+
+  return static_cast<T>(clamped);
+}
+
+template <typename T>
 TfLiteStatus GetSize(TfLiteContext* context, T start, T limit, T delta,
                      int* size) {
-  TF_LITE_ENSURE(context, !std::equal_to<T>()(delta, 0));
+  // TF_LITE_ENSURE(context, !std::equal_to<T>()(delta, 0)); // std::equal_to
+  // does not support float16 and bfloat16
+  TF_LITE_ENSURE(context, !(delta == 0));
   TF_LITE_ENSURE(
       context, (start >= limit && delta < 0) || (start <= limit && delta > 0));
   *size =
       (std::is_integral<T>::value
            ? ((std::abs(limit - start) + std::abs(delta) - 1) / std::abs(delta))
            : std::ceil(std::abs((limit - start) / delta)));
+  return kTfLiteOk;
+}
+
+template <typename T>
+TfLiteStatus GetSizeQuantized(TfLiteContext* context, const TfLiteTensor* start,
+                              const TfLiteTensor* limit,
+                              const TfLiteTensor* delta, int* size) {
+  const float dequantized_start_value = dequantize_value<T>(start);
+  const float dequantized_delta_value = dequantize_value<T>(delta);
+  const float dequantized_limit_value = dequantize_value<T>(limit);
+
+  TF_LITE_ENSURE(context, !(dequantized_delta_value == 0));
+  TF_LITE_ENSURE(context,
+                 (dequantized_start_value >= dequantized_limit_value &&
+                  dequantized_delta_value < 0) ||
+                     (dequantized_start_value <= dequantized_limit_value &&
+                      dequantized_delta_value > 0));
+  *size = (std::is_integral<T>::value
+               ? ((std::abs(dequantized_limit_value - dequantized_start_value) +
+                   std::abs(dequantized_delta_value) - 1) /
+                  std::abs(dequantized_delta_value))
+               : std::ceil(std::abs(
+                     (dequantized_limit_value - dequantized_start_value) /
+                     dequantized_delta_value)));
   return kTfLiteOk;
 }
 
@@ -81,6 +129,37 @@ TfLiteStatus ResizeOutput(TfLiteContext* context, const TfLiteTensor* start,
                                          *GetTensorData<float>(delta), &size));
       break;
     }
+    case kTfLiteInt8: {
+      TF_LITE_ENSURE_OK(context, GetSizeQuantized<int8_t>(context, start, limit,
+                                                          delta, &size));
+      break;
+    }
+    case kTfLiteInt16: {
+      if (start->quantization.type == kTfLiteAffineQuantization) {
+        TF_LITE_ENSURE_OK(context, GetSizeQuantized<int16_t>(
+                                       context, start, limit, delta, &size));
+      } else {
+        TF_LITE_ENSURE_OK(context,
+                          GetSize(context, *GetTensorData<int16_t>(start),
+                                  *GetTensorData<int16_t>(limit),
+                                  *GetTensorData<int16_t>(delta), &size));
+      }
+      break;
+    }
+    case kTfLiteFloat16: {
+      TF_LITE_ENSURE_OK(context,
+                        GetSize(context, *GetTensorData<Eigen::half>(start),
+                                *GetTensorData<Eigen::half>(limit),
+                                *GetTensorData<Eigen::half>(delta), &size));
+      break;
+    }
+    case kTfLiteBFloat16: {
+      TF_LITE_ENSURE_OK(context,
+                        GetSize(context, *GetTensorData<Eigen::bfloat16>(start),
+                                *GetTensorData<Eigen::bfloat16>(limit),
+                                *GetTensorData<Eigen::bfloat16>(delta), &size));
+      break;
+    }
     default: {
       TF_LITE_KERNEL_LOG(context, "Unknown data type: %d", start->type);
       return kTfLiteError;
@@ -105,6 +184,25 @@ void CalculateRange(const TfLiteTensor* start, const TfLiteTensor* delta,
   }
 }
 
+template <typename T>
+void CalculateRangeQuantized(const TfLiteTensor* start,
+                             const TfLiteTensor* delta, TfLiteTensor* output) {
+  int32_t zero_point = start->params.zero_point;
+  const double scale = start->params.scale;
+
+  const float dequantized_start_value = dequantize_value<T>(start);
+  const float dequantized_delta_value = dequantize_value<T>(delta);
+
+  T* output_data = GetTensorData<T>(output);
+
+  const int num_elements = NumElements(output);
+  float value = dequantized_start_value;
+  for (int i = 0; i < num_elements; ++i) {
+    output_data[i] = quantize_value<T>(value, scale, zero_point);
+    value += dequantized_delta_value;
+  }
+}
+
 TfLiteStatus EvalImpl(TfLiteContext* context, const TfLiteTensor* start,
                       const TfLiteTensor* delta, TfLiteTensor* output) {
   switch (output->type) {
@@ -118,6 +216,24 @@ TfLiteStatus EvalImpl(TfLiteContext* context, const TfLiteTensor* start,
     }
     case kTfLiteInt64: {
       CalculateRange<int64_t>(start, delta, output);
+      break;
+    }
+    case kTfLiteInt8: {
+      CalculateRangeQuantized<int8_t>(start, delta, output);
+      break;
+    }
+    case kTfLiteInt16: {
+      start->quantization.type == kTfLiteAffineQuantization
+          ? CalculateRangeQuantized<int16_t>(start, delta, output)
+          : CalculateRange<int16_t>(start, delta, output);
+      break;
+    }
+    case kTfLiteFloat16: {
+      CalculateRange<Eigen::half>(start, delta, output);
+      break;
+    }
+    case kTfLiteBFloat16: {
+      CalculateRange<Eigen::bfloat16>(start, delta, output);
       break;
     }
     default: {
@@ -149,7 +265,9 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   // TODO(b/117912892): Support quantization as well.
   const auto dtype = start->type;
   if (dtype != kTfLiteFloat32 && dtype != kTfLiteInt32 &&
-      dtype != kTfLiteInt64) {
+      dtype != kTfLiteInt64 && dtype != kTfLiteInt8 &&
+      dtype != kTfLiteFloat16 && dtype != kTfLiteBFloat16 &&
+      dtype != kTfLiteInt16) {
     TF_LITE_KERNEL_LOG(context, "Unknown index output data type: %s",
                        TfLiteTypeGetName(dtype));
     return kTfLiteError;

--- a/tensorflow/lite/kernels/range_test.cc
+++ b/tensorflow/lite/kernels/range_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "Eigen/Core"
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
@@ -50,12 +51,40 @@ class RangeOpModel : public SingleOpModel {
     BuildInterpreter({GetShape(start_), GetShape(limit_), GetShape(delta_)});
   }
 
+  explicit RangeOpModel(const TensorData& start, const TensorData& limit,
+                        const TensorData& delta) {
+    start_ = AddInput(start);
+    limit_ = AddInput(limit);
+    delta_ = AddInput(delta);
+    output_ = AddOutput(start.type);
+    SetBuiltinOp(BuiltinOperator_RANGE, BuiltinOptions_RangeOptions,
+                 CreateRangeOptions(builder_).Union());
+    BuildInterpreter({GetShape(start_), GetShape(limit_), GetShape(delta_)});
+  }
+
   int start() { return start_; }
   int limit() { return limit_; }
   int delta() { return delta_; }
 
   std::vector<T> GetOutput() { return ExtractVector<T>(output_); }
   std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+  int output() const { return output_; }
+
+  template <typename output_type>
+  std::vector<output_type> ExtractDequantVector(int index) {
+    auto vec = ExtractVector<T>(index);
+    TfLiteTensor* t = interpreter_->tensor(index);
+    auto* affine_quantization =
+        reinterpret_cast<TfLiteAffineQuantization*>(t->quantization.params);
+    float scaling_factor = affine_quantization->scale->data[0];
+    int zero_point = affine_quantization->zero_point->data[0];
+    std::vector<output_type> output;
+    for (const auto& v : vec) {
+      output.push_back(static_cast<output_type>(
+          (static_cast<output_type>(v) - zero_point) * scaling_factor));
+    }
+    return output;
+  }
 
  private:
   int start_;
@@ -63,6 +92,15 @@ class RangeOpModel : public SingleOpModel {
   int delta_;
   int output_;
 };
+
+// for quantized, the error shouldn't exceed step
+template <typename T>
+float GetTolerance(float min, float max) {
+  float kQuantizedStep =
+      2.0 * (max - min) /
+      (std::numeric_limits<T>::max() - std::numeric_limits<T>::min());
+  return kQuantizedStep;
+}
 
 TEST(RangeOpModel, Simple) {
   RangeOpModel<int32_t> model(TensorType_INT32);
@@ -246,6 +284,157 @@ TEST(RangeOpModel, Int64EmptyOutput) {
 
 TEST(RangeOpModel, Int64EmptyOutputConst) {
   RangeOpModel<int64_t> model(TensorType_INT64, {0}, {0}, {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
+  EXPECT_THAT(model.GetOutput(), ElementsAre());
+}
+
+TEST(RangeOpModel, SimpleInt8Quantized) {
+  float kQuantizedTolerance = GetTolerance<int8_t>(-0.0f, 128.0f);
+  RangeOpModel<int8_t> model({TensorType_INT8, {}, 0.0f, 128.0f},
+                             {TensorType_INT8, {}, 0.0f, 128.0f},
+                             {TensorType_INT8, {}, 0.0f, 128.0f});
+  model.QuantizeAndPopulate<int8_t>(model.start(), {0.0f});
+  model.QuantizeAndPopulate<int8_t>(model.limit(), {4.0f});
+  model.QuantizeAndPopulate<int8_t>(model.delta(), {1.5f});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(3));
+  EXPECT_THAT(
+      model.ExtractDequantVector<float>(model.output()),
+      ElementsAreArray(ArrayFloatNear({0.0, 1.5, 3.0}, kQuantizedTolerance)));
+}
+
+TEST(RangeOpModel, SimpleInt16) {
+  RangeOpModel<int16_t> model(TensorType_INT16);
+  model.PopulateTensor<int16_t>(model.start(), {0});
+  model.PopulateTensor<int16_t>(model.limit(), {4});
+  model.PopulateTensor<int16_t>(model.delta(), {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(0, 1, 2, 3));
+}
+
+TEST(RangeOpModel, SimpleFloat16) {
+  RangeOpModel<Eigen::half> model(TensorType_FLOAT16);
+  model.PopulateTensor<Eigen::half>(model.start(), {Eigen::half(0)});
+  model.PopulateTensor<Eigen::half>(model.limit(), {Eigen::half(4)});
+  model.PopulateTensor<Eigen::half>(model.delta(), {Eigen::half(1)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(Eigen::half(0), Eigen::half(1),
+                                             Eigen::half(2), Eigen::half(3)));
+}
+
+TEST(RangeOpModel, SimpleBFloat16) {
+  RangeOpModel<Eigen::bfloat16> model(TensorType_BFLOAT16);
+  model.PopulateTensor<Eigen::bfloat16>(model.start(), {Eigen::bfloat16(0)});
+  model.PopulateTensor<Eigen::bfloat16>(model.limit(), {Eigen::bfloat16(4)});
+  model.PopulateTensor<Eigen::bfloat16>(model.delta(), {Eigen::bfloat16(1)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAre(Eigen::bfloat16(0), Eigen::bfloat16(1),
+                          Eigen::bfloat16(2), Eigen::bfloat16(3)));
+}
+
+TEST(RangeOpModel, Int8DeltaGreaterThanOneConst) {
+  RangeOpModel<int8_t> model({TensorType_INT8, {}, 0, 128},
+                             {TensorType_INT8, {}, 0, 128},
+                             {TensorType_INT8, {}, 0, 128});
+  model.QuantizeAndPopulate<int8_t>(model.start(), {2});
+  model.QuantizeAndPopulate<int8_t>(model.limit(), {9});
+  model.QuantizeAndPopulate<int8_t>(model.delta(), {2});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.ExtractDequantVector<int8_t>(model.output()),
+              ElementsAre(2, 4, 6, 8));
+}
+
+TEST(RangeOpModel, Int16QuantizedDeltaGreaterThanOneConst) {
+  RangeOpModel<int16_t> model({TensorType_INT16, {}, 0, 128},
+                              {TensorType_INT16, {}, 0, 128},
+                              {TensorType_INT16, {}, 0, 128});
+  model.QuantizeAndPopulate<int16_t>(model.start(), {2});
+  model.QuantizeAndPopulate<int16_t>(model.limit(), {9});
+  model.QuantizeAndPopulate<int16_t>(model.delta(), {2});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.ExtractDequantVector<int16_t>(model.output()),
+              ElementsAre(2, 4, 6, 8));
+}
+
+TEST(RangeOpModel, Int16DeltaGreaterThanOneConst) {
+  RangeOpModel<int16_t> model(TensorType_INT16, {2}, {9}, {2});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(2, 4, 6, 8));
+}
+
+TEST(RangeOpModel, Float16DeltaGreaterThanOneConst) {
+  RangeOpModel<Eigen::half> model(TensorType_FLOAT16, {Eigen::half(2)},
+                                  {Eigen::half(9)}, {Eigen::half(2)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(Eigen::half(2), Eigen::half(4),
+                                             Eigen::half(6), Eigen::half(8)));
+}
+
+TEST(RangeOpModel, BFloat16DeltaGreaterThanOneConst) {
+  RangeOpModel<Eigen::bfloat16> model(TensorType_BFLOAT16, {Eigen::bfloat16(2)},
+                                      {Eigen::bfloat16(9)},
+                                      {Eigen::bfloat16(2)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAre(Eigen::bfloat16(2), Eigen::bfloat16(4),
+                          Eigen::bfloat16(6), Eigen::bfloat16(8)));
+}
+
+TEST(RangeOpModel, Int8EmptyOutputConst) {
+  RangeOpModel<int8_t> model({TensorType_INT8, {}, 0, 128},
+                             {TensorType_INT8, {}, 0, 128},
+                             {TensorType_INT8, {}, 0, 128});
+  model.QuantizeAndPopulate<int8_t>(model.start(), {0});
+  model.QuantizeAndPopulate<int8_t>(model.limit(), {0});
+  model.QuantizeAndPopulate<int8_t>(model.delta(), {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
+  EXPECT_THAT(model.ExtractDequantVector<int8_t>(model.output()),
+              ElementsAre());
+}
+
+TEST(RangeOpModel, Int16EmptyOutputConstExample1) {
+  RangeOpModel<int16_t> model({TensorType_INT16, {}, 0, 128},
+                              {TensorType_INT16, {}, 0, 128},
+                              {TensorType_INT16, {}, 0, 128});
+  model.QuantizeAndPopulate<int16_t>(model.start(), {0});
+  model.QuantizeAndPopulate<int16_t>(model.limit(), {0});
+  model.QuantizeAndPopulate<int16_t>(model.delta(), {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
+  EXPECT_THAT(model.ExtractDequantVector<int16_t>(model.output()),
+              ElementsAre());
+}
+
+TEST(RangeOpModel, Int16EmptyOutputConstExample2) {
+  RangeOpModel<int16_t> model(TensorType_INT16, {0}, {0}, {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
+  EXPECT_THAT(model.GetOutput(), ElementsAre());
+}
+
+TEST(RangeOpModel, Float16EmptyOutputConst) {
+  RangeOpModel<Eigen::half> model(TensorType_FLOAT16, {Eigen::half(0)},
+                                  {Eigen::half(0)}, {Eigen::half(1)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
+  EXPECT_THAT(model.GetOutput(), ElementsAre());
+}
+
+TEST(RangeOpModel, BFloat16EmptyOutputConst) {
+  RangeOpModel<Eigen::bfloat16> model(TensorType_BFLOAT16, {Eigen::bfloat16(0)},
+                                      {Eigen::bfloat16(0)},
+                                      {Eigen::bfloat16(1)});
   ASSERT_EQ(model.Invoke(), kTfLiteOk);
   EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
   EXPECT_THAT(model.GetOutput(), ElementsAre());

--- a/tensorflow/lite/kernels/range_test.cc
+++ b/tensorflow/lite/kernels/range_test.cc
@@ -289,6 +289,16 @@ TEST(RangeOpModel, Int64EmptyOutputConst) {
   EXPECT_THAT(model.GetOutput(), ElementsAre());
 }
 
+TEST(RangeOpModel, SimpleInt8) {
+  RangeOpModel<int8_t> model(TensorType_INT8);
+  model.PopulateTensor<int8_t>(model.start(), {0});
+  model.PopulateTensor<int8_t>(model.limit(), {4});
+  model.PopulateTensor<int8_t>(model.delta(), {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(0, 1, 2, 3));
+}
+
 TEST(RangeOpModel, SimpleInt8Quantized) {
   float kQuantizedTolerance = GetTolerance<int8_t>(-0.0f, 128.0f);
   RangeOpModel<int8_t> model({TensorType_INT8, {}, 0.0f, 128.0f},
@@ -337,7 +347,7 @@ TEST(RangeOpModel, SimpleBFloat16) {
                           Eigen::bfloat16(2), Eigen::bfloat16(3)));
 }
 
-TEST(RangeOpModel, Int8DeltaGreaterThanOneConst) {
+TEST(RangeOpModel, Int8QuantizedDeltaGreaterThanOneConst) {
   RangeOpModel<int8_t> model({TensorType_INT8, {}, 0, 128},
                              {TensorType_INT8, {}, 0, 128},
                              {TensorType_INT8, {}, 0, 128});
@@ -348,6 +358,13 @@ TEST(RangeOpModel, Int8DeltaGreaterThanOneConst) {
   EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
   EXPECT_THAT(model.ExtractDequantVector<int8_t>(model.output()),
               ElementsAre(2, 4, 6, 8));
+}
+
+TEST(RangeOpModel, Int8DeltaGreaterThanOneConst) {
+  RangeOpModel<int8_t> model(TensorType_INT8, {2}, {9}, {2});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(), ElementsAre(2, 4, 6, 8));
 }
 
 TEST(RangeOpModel, Int16QuantizedDeltaGreaterThanOneConst) {
@@ -390,7 +407,7 @@ TEST(RangeOpModel, BFloat16DeltaGreaterThanOneConst) {
                           Eigen::bfloat16(6), Eigen::bfloat16(8)));
 }
 
-TEST(RangeOpModel, Int8EmptyOutputConst) {
+TEST(RangeOpModel, Int8EmptyOutputConstExample1) {
   RangeOpModel<int8_t> model({TensorType_INT8, {}, 0, 128},
                              {TensorType_INT8, {}, 0, 128},
                              {TensorType_INT8, {}, 0, 128});
@@ -401,6 +418,13 @@ TEST(RangeOpModel, Int8EmptyOutputConst) {
   EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
   EXPECT_THAT(model.ExtractDequantVector<int8_t>(model.output()),
               ElementsAre());
+}
+
+TEST(RangeOpModel, Int8EmptyOutputConstExample2) {
+  RangeOpModel<int8_t> model(TensorType_INT8, {0}, {0}, {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(0));
+  EXPECT_THAT(model.GetOutput(), ElementsAre());
 }
 
 TEST(RangeOpModel, Int16EmptyOutputConstExample1) {

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
-Adds i8,i16,bf16,f16 for tflite range.
-Adds i8,i16,bf16,f16 range unit tests.