### PR TITLE
Tflite ceil missing datatypes support

### DIFF
--- a/tensorflow/lite/kernels/ceil.cc
+++ b/tensorflow/lite/kernels/ceil.cc
@@ -36,10 +36,77 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
                     GetOutputSafe(context, node, kOutputTensor, &output));
   TF_LITE_ENSURE_EQ(context, NumInputs(node), 1);
   TF_LITE_ENSURE_EQ(context, NumOutputs(node), 1);
-  TF_LITE_ENSURE_TYPES_EQ(context, input->type, kTfLiteFloat32);
+  TF_LITE_ENSURE(
+      context,
+      input->type == kTfLiteFloat32 || input->type == kTfLiteBFloat16 ||
+          input->type == kTfLiteFloat16 || input->type == kTfLiteInt32 ||
+          input->type == kTfLiteInt16 || input->type == kTfLiteInt8);
+
+  bool is_quantized = input->quantization.type != kTfLiteNoQuantization;
+  if (input->type == kTfLiteInt8 ||
+      (input->type == kTfLiteInt16 && is_quantized)) {
+    const auto* input_params =
+        reinterpret_cast<TfLiteAffineQuantization*>(input->quantization.params);
+    const auto* output_params = reinterpret_cast<TfLiteAffineQuantization*>(
+        output->quantization.params);
+
+    TF_LITE_ENSURE(context, input_params != nullptr);
+    TF_LITE_ENSURE(context, input_params->scale != nullptr);
+    TF_LITE_ENSURE(context, input_params->scale->size > 0);
+    TF_LITE_ENSURE(context, input_params->zero_point->size > 0);
+
+    TF_LITE_ENSURE(context, output_params != nullptr);
+    TF_LITE_ENSURE(context, output_params->scale != nullptr);
+    TF_LITE_ENSURE(context, output_params->scale->size > 0);
+    TF_LITE_ENSURE(context, output_params->zero_point->size > 0);
+
+    if (input->type == kTfLiteInt16) {
+      // In case of int16, quantization is symmetic and
+      // zero point should be zero.
+      TF_LITE_ENSURE_EQ(context, input->params.zero_point, 0);
+      TF_LITE_ENSURE_EQ(context, output->params.zero_point, 0);
+    }
+  }
+
   output->type = input->type;
   TfLiteIntArray* output_size = TfLiteIntArrayCopy(input->dims);
   return context->ResizeTensor(context, output, output_size);
+}
+
+template <typename T>
+TfLiteStatus EvalCeil(const TfLiteTensor* input, TfLiteTensor* output) {
+  optimized_ops::Ceil<T>(GetTensorShape(input), GetTensorData<T>(input),
+                         GetTensorShape(output), GetTensorData<T>(output));
+  return TfLiteStatus::kTfLiteOk;
+}
+
+template <typename T>
+TfLiteStatus EvalCeilQuantized(const TfLiteTensor* input,
+                               TfLiteTensor* output) {
+  const int32_t input_zero_point = input->params.zero_point;
+  const float input_scale = input->params.scale;
+  const int32_t output_zero_point = output->params.zero_point;
+  const float output_scale = output->params.scale;
+
+  const int num_elements = NumElements(input);
+  const T* input_data = GetTensorData<T>(input);
+  T* output_data = GetTensorData<T>(output);
+
+  for (int i = 0; i < num_elements; ++i) {
+    const float input_value = (input_data[i] - input_zero_point) * input_scale;
+    const float ceiled_value = std::ceil(input_value);
+    int32_t quantized_value =
+        static_cast<int32_t>(std::round(ceiled_value / output_scale)) +
+        output_zero_point;
+    // Clamp the value to fit in the range of the output type
+    quantized_value =
+        std::min(std::max(quantized_value,
+                          static_cast<int32_t>(std::numeric_limits<T>::min())),
+                 static_cast<int32_t>(std::numeric_limits<T>::max()));
+
+    output_data[i] = static_cast<T>(quantized_value);
+  }
+  return TfLiteStatus::kTfLiteOk;
 }
 
 TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
@@ -48,13 +115,35 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
   TfLiteTensor* output;
   TF_LITE_ENSURE_OK(context,
                     GetOutputSafe(context, node, kOutputTensor, &output));
-  if (input->type != kTfLiteFloat32) {
-    TF_LITE_UNSUPPORTED_TYPE(context, input->type, "Ceil");
+
+  switch (input->type) {
+    case kTfLiteFloat32:
+      TF_LITE_ENSURE_OK(context, EvalCeil<float>(input, output));
+      break;
+    case kTfLiteFloat16:
+      TF_LITE_ENSURE_OK(context, EvalCeil<Eigen::half>(input, output));
+      break;
+    case kTfLiteBFloat16:
+      TF_LITE_ENSURE_OK(context, EvalCeil<Eigen::bfloat16>(input, output));
+      break;
+    case kTfLiteInt32:
+      TF_LITE_ENSURE_OK(context, EvalCeil<int32_t>(input, output));
+      break;
+    case kTfLiteInt8:
+      TF_LITE_ENSURE_OK(context, EvalCeilQuantized<int8_t>(input, output));
+      break;
+    case kTfLiteInt16: {
+      if (output->quantization.type == kTfLiteNoQuantization)
+        TF_LITE_ENSURE_OK(context, EvalCeil<int16_t>(input, output));
+      else
+        TF_LITE_ENSURE_OK(context, EvalCeilQuantized<int16_t>(input, output));
+    } break;
+    default: {
+      TF_LITE_KERNEL_LOG(context, "Unsupported datatype for ceil output: %s",
+                         TfLiteTypeGetName(output->type));
+      return TfLiteStatus::kTfLiteError;
+    }
   }
-
-  optimized_ops::Ceil(GetTensorShape(input), GetTensorData<float>(input),
-                      GetTensorShape(output), GetTensorData<float>(output));
-
   return kTfLiteOk;
 }
 }  // namespace ceil

--- a/tensorflow/lite/kernels/ceil.cc
+++ b/tensorflow/lite/kernels/ceil.cc
@@ -43,7 +43,7 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
           input->type == kTfLiteInt16 || input->type == kTfLiteInt8);
 
   bool is_quantized = input->quantization.type != kTfLiteNoQuantization;
-  if (input->type == kTfLiteInt8 ||
+  if ((input->type == kTfLiteInt8 && is_quantized) ||
       (input->type == kTfLiteInt16 && is_quantized)) {
     const auto* input_params =
         reinterpret_cast<TfLiteAffineQuantization*>(input->quantization.params);
@@ -129,9 +129,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
     case kTfLiteInt32:
       TF_LITE_ENSURE_OK(context, EvalCeil<int32_t>(input, output));
       break;
-    case kTfLiteInt8:
-      TF_LITE_ENSURE_OK(context, EvalCeilQuantized<int8_t>(input, output));
-      break;
+    case kTfLiteInt8: {
+      if (output->quantization.type == kTfLiteNoQuantization)
+        TF_LITE_ENSURE_OK(context, EvalCeil<int8_t>(input, output));
+      else  
+        TF_LITE_ENSURE_OK(context, EvalCeilQuantized<int8_t>(input, output));
+      } break;
     case kTfLiteInt16: {
       if (output->quantization.type == kTfLiteNoQuantization)
         TF_LITE_ENSURE_OK(context, EvalCeil<int16_t>(input, output));

--- a/tensorflow/lite/kernels/ceil_test.cc
+++ b/tensorflow/lite/kernels/ceil_test.cc
@@ -29,30 +29,74 @@ using ::testing::ElementsAreArray;
 class CeilOpModel : public SingleOpModel {
  public:
   CeilOpModel(std::initializer_list<int> input_shape, TensorType input_type) {
-    input_ = AddInput(TensorType_FLOAT32);
-    output_ = AddOutput(TensorType_FLOAT32);
+    input_ = AddInput(input_type);
+    output_ = AddOutput(input_type);
     SetBuiltinOp(BuiltinOperator_CEIL, BuiltinOptions_NONE, 0);
     BuildInterpreter({
         input_shape,
     });
   }
+  CeilOpModel(const TensorData& input, const TensorData& output) {
+    input_ = AddInput(SymmetricInt16Scaling(input));
+    output_ = AddOutput(SymmetricInt16Scaling(output));
+    SetBuiltinOp(BuiltinOperator_CEIL, BuiltinOptions_NONE, 0);
+    BuildInterpreter({
+        GetShape(input_),
+    });
+  }
 
   int input() { return input_; }
 
-  std::vector<float> GetOutput() { return ExtractVector<float>(output_); }
+  template <typename T>
+  std::vector<T> GetOutput() {
+    return ExtractVector<T>(output_);
+  }
   std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
+  template <typename integer_dtype>
+  std::vector<float> GetDequantizedOutput() {
+    return Dequantize<integer_dtype>(ExtractVector<integer_dtype>(output_),
+                                     GetScale(output_), GetZeroPoint(output_));
+  }
 
- private:
+ protected:
   int input_;
   int output_;
+
+  TensorData SymmetricInt16Scaling(TensorData tensor) {
+    // Symmetric range and null zero-point is required for INT16 tensors. As
+    // SingleOpModel::QuantizationParams calculates the scale on an asymmetric
+    // base [int_type::min, int_type::max], manually calculate the scale on a
+    // symmetric range [int_type::min+1, int_type::max] to ensure a null
+    // zero-point.
+    if (tensor.type == TensorType_INT16) {
+      CHECK_EQ(std::abs(tensor.min), tensor.max);
+      tensor.scale = tensor.max / std::numeric_limits<int16_t>::max();
+      tensor.zero_point = 0;
+      tensor.min = 0;
+      tensor.max = 0;
+    }
+    return tensor;
+  }
 };
 
 TEST(CeilOpTest, SingleDim) {
   CeilOpModel model({2}, TensorType_FLOAT32);
   model.PopulateTensor<float>(model.input(), {8.5, 0.0});
   ASSERT_EQ(model.Invoke(), kTfLiteOk);
-  EXPECT_THAT(model.GetOutput(), ElementsAreArray({9, 0}));
+  EXPECT_THAT(model.GetOutput<float>(), ElementsAreArray({9, 0}));
   EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2}));
+}
+
+TEST(CeilOpTest, SingleDimFloat16) {
+  CeilOpModel model({6}, TensorType_FLOAT16);
+  std::vector<Eigen::half> input_data{
+      Eigen::half{-535.54f}, Eigen::half{-100.0f}, Eigen::half{-1.0f},
+      Eigen::half{0.f},      Eigen::half{1.0f},    Eigen::half{100.32f}};
+  model.PopulateTensor<Eigen::half>(model.input(), input_data);
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  ASSERT_THAT(model.GetOutputShape(), ElementsAreArray({6}));
+  EXPECT_THAT(model.GetOutput<Eigen::half>(),
+              ElementsAreArray({-535.0f, -100.0f, -1.0f, 0.f, 1.0f, 101.0f}));
 }
 
 TEST(CeilOpTest, MultiDims) {
@@ -70,9 +114,65 @@ TEST(CeilOpTest, MultiDims) {
                                                  -0.5,
                                              });
   ASSERT_EQ(model.Invoke(), kTfLiteOk);
-  EXPECT_THAT(model.GetOutput(),
+  EXPECT_THAT(model.GetOutput<float>(),
               ElementsAreArray({1, 9, 1, 10, 1, 0, -8, 0, -9, 0}));
   EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 1, 1, 5}));
+}
+
+TEST(CeilOpTest, MultiDimsBFloat16) {
+  CeilOpModel model({2, 2}, TensorType_BFLOAT16);
+  std::vector<Eigen::bfloat16> input_data{
+      Eigen::bfloat16{-32.230f}, Eigen::bfloat16{-100.3222134f},
+      Eigen::bfloat16{19.230f}, Eigen::bfloat16{35.32134f}};
+  model.PopulateTensor<Eigen::bfloat16>(model.input(), input_data);
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  ASSERT_THAT(model.GetOutputShape(), ElementsAreArray({2, 2}));
+  EXPECT_THAT(model.GetOutput<Eigen::bfloat16>(),
+              ElementsAreArray({-32.0f, -100.0f, 20.0f, 36.0f}));
+}
+
+template <typename T>
+float GetTolerance(float min, float max) {
+  float kQuantizedStep = (max - min) / (std::numeric_limits<T>::max() -
+                                        std::numeric_limits<T>::min());
+  return kQuantizedStep;
+}
+
+template <TensorType tensor_type, typename integer_dtype>
+void QuantizedTestsNoActivation() {
+  float kQuantizedTolerance = GetTolerance<integer_dtype>(-7.0, 7.0);
+  std::vector<float> input = {-6.2, -5.3, 0, 1.2, 4.4, 6.0};
+  std::vector<float> result = {-6.0, -5.0, 0, 2.0, 5.0, 6.0};
+
+  CeilOpModel model({tensor_type, {6}, -7.0, 7.0},
+                    {tensor_type, {}, -7.0, 7.0});
+  model.QuantizeAndPopulate<integer_dtype>(model.input(), input);
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  ASSERT_THAT(model.GetOutputShape(), ElementsAreArray({6}));
+  EXPECT_THAT(model.GetDequantizedOutput<integer_dtype>(),
+              ElementsAreArray(ArrayFloatNear(result, kQuantizedTolerance)));
+}
+
+TEST(QuantizedCeilOpModel, QuantizedTestsNoActivationInt8) {
+  QuantizedTestsNoActivation<TensorType_INT8, int8_t>();
+}
+
+TEST(QuantizedCeilOpModel, QuantizedTestsNoActivationInt16) {
+  QuantizedTestsNoActivation<TensorType_INT16, int16_t>();
+}
+
+TEST(QuantizedCeilOpModel, QuantizedTestsNoActivationInt8DifferentMinMax) {
+  float kQuantizedTolerance = GetTolerance<int8_t>(-20.0, 15.0);
+  std::vector<float> input = {-6.4, -12.0, 0, -19.0, 4.8, 15.0};
+  std::vector<float> result = {-6.0, -12.0, 0, -19.0, 5.0, 15.0};
+
+  CeilOpModel model({TensorType_INT8, {6}, -19.0, 15.0},
+                    {TensorType_INT8, {}, -19.0, 15.0});
+  model.QuantizeAndPopulate<int8_t>(model.input(), input);
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  ASSERT_THAT(model.GetOutputShape(), ElementsAreArray({6}));
+  EXPECT_THAT(model.GetDequantizedOutput<int8_t>(),
+              ElementsAreArray(ArrayFloatNear(result, kQuantizedTolerance)));
 }
 
 }  // namespace

--- a/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
+++ b/tensorflow/lite/kernels/internal/optimized/optimized_ops.h
@@ -4230,8 +4230,9 @@ inline void Floor(const RuntimeShape& input_shape, const float* input_data,
   output_map.array() = Eigen::floor(input_map.array());
 }
 
-inline void Ceil(const RuntimeShape& input_shape, const float* input_data,
-                 const RuntimeShape& output_shape, float* output_data) {
+template <typename T>
+inline void Ceil(const RuntimeShape& input_shape, const T* input_data,
+                 const RuntimeShape& output_shape, T* output_data) {
   ruy::profiler::ScopeLabel label("Ceil");
   auto input_map = MapAsVector(input_data, input_shape);
   auto output_map = MapAsVector(output_data, output_shape);

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
-Adds bf16,f16,i8,i16,i32 for tflite ceil operations 
-Adds bf16,f16,i8,i16,i32 ceil unit tests