### PR TITLE
TfLite exp missing datatype support (#29)

### DIFF
--- a/tensorflow/lite/kernels/exp.cc
+++ b/tensorflow/lite/kernels/exp.cc
@@ -99,6 +99,16 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                            NumElements(op_context.input),
                            GetTensorData<float>(op_context.output));
         break;
+      case kTfLiteFloat16:
+        reference_ops::Exp(GetTensorData<Eigen::half>(op_context.input),
+                           NumElements(op_context.input),
+                           GetTensorData<Eigen::half>(op_context.output));
+        break;
+      case kTfLiteBFloat16:
+        reference_ops::Exp(GetTensorData<Eigen::bfloat16>(op_context.input),
+                           NumElements(op_context.input),
+                           GetTensorData<Eigen::bfloat16>(op_context.output));
+        break;
       case kTfLiteInt8:
         reference_integer_ops::LookupTable(
             GetTensorData<int8_t>(op_context.input),

--- a/tensorflow/lite/kernels/internal/reference/exp.h
+++ b/tensorflow/lite/kernels/internal/reference/exp.h
@@ -28,7 +28,7 @@ inline void Exp(const T* input_data, const size_t num_elements,
                 T* output_data) {
   ruy::profiler::ScopeLabel label("Exp");
   for (size_t idx = 0; idx < num_elements; ++idx) {
-    output_data[idx] = std::exp(input_data[idx]);
+    output_data[idx] = static_cast<T>(std::exp(input_data[idx]));
   }
 }
 

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
- Adds bf16, f16 support exp function
- Adds bf16, f16 unit tests