### PR TITLE
TfLite Reverse missing datatype support (#31)

### DIFF
--- a/tensorflow/lite/kernels/reverse.cc
+++ b/tensorflow/lite/kernels/reverse.cc
@@ -50,7 +50,8 @@ TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
   if (input->type != kTfLiteInt32 && input->type != kTfLiteFloat32 &&
       input->type != kTfLiteUInt8 && input->type != kTfLiteInt8 &&
       input->type != kTfLiteInt16 && input->type != kTfLiteInt64 &&
-      input->type != kTfLiteBool) {
+      input->type != kTfLiteBool && input->type != kTfLiteFloat16 &&
+      input->type != kTfLiteBFloat16) {
     TF_LITE_KERNEL_LOG(context, "Type '%s' is not supported by reverse.",
                        TfLiteTypeGetName(input->type));
     return kTfLiteError;
@@ -146,6 +147,19 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       reference_ops::Reverse<bool>(axes, num_axes, GetTensorShape(input),
                                    GetTensorData<bool>(input),
                                    GetTensorData<bool>(output));
+      break;
+    }
+    case kTfLiteFloat16: {
+      reference_ops::Reverse<Eigen::half>(axes, num_axes, GetTensorShape(input),
+                                          GetTensorData<Eigen::half>(input),
+                                          GetTensorData<Eigen::half>(output));
+      break;
+    }
+    case kTfLiteBFloat16: {
+      reference_ops::Reverse<Eigen::bfloat16>(
+          axes, num_axes, GetTensorShape(input),
+          GetTensorData<Eigen::bfloat16>(input),
+          GetTensorData<Eigen::bfloat16>(output));
       break;
     }
     default: {

--- a/tensorflow/lite/kernels/reverse_test.cc
+++ b/tensorflow/lite/kernels/reverse_test.cc
@@ -352,5 +352,94 @@ TEST(ReverseOpTest, Int16MultiDimensions) {
                         17, 18, 15, 16, 13, 14, 23, 24, 21, 22, 19, 20}));
 }
 
+// float16 tests.
+TEST(ReverseOpTest, Float16OneDimension) {
+  ReverseOpModel<Eigen::half> model({TensorType_FLOAT16, {4}},
+                                    {TensorType_INT32, {1}});
+  model.PopulateTensor<Eigen::half>(
+      model.input(),
+      {Eigen::half(1), Eigen::half(2), Eigen::half(3), Eigen::half(4)});
+  model.PopulateTensor<int32_t>(model.axis(), {0});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAreArray({Eigen::half(4), Eigen::half(3), Eigen::half(2),
+                                Eigen::half(1)}));
+}
+
+TEST(ReverseOpTest, Float16MultiDimensions) {
+  ReverseOpModel<Eigen::half> model({TensorType_FLOAT16, {4, 3, 2}},
+                                    {TensorType_INT32, {1}});
+  model.PopulateTensor<Eigen::half>(
+      model.input(),
+      {Eigen::half(1),  Eigen::half(2),  Eigen::half(3),  Eigen::half(4),
+       Eigen::half(5),  Eigen::half(6),  Eigen::half(7),  Eigen::half(8),
+       Eigen::half(9),  Eigen::half(10), Eigen::half(11), Eigen::half(12),
+       Eigen::half(13), Eigen::half(14), Eigen::half(15), Eigen::half(16),
+       Eigen::half(17), Eigen::half(18), Eigen::half(19), Eigen::half(20),
+       Eigen::half(21), Eigen::half(22), Eigen::half(23), Eigen::half(24)});
+  model.PopulateTensor<int32_t>(model.axis(), {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4, 3, 2));
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({Eigen::half(5),  Eigen::half(6),  Eigen::half(3),
+                        Eigen::half(4),  Eigen::half(1),  Eigen::half(2),
+                        Eigen::half(11), Eigen::half(12), Eigen::half(9),
+                        Eigen::half(10), Eigen::half(7),  Eigen::half(8),
+                        Eigen::half(17), Eigen::half(18), Eigen::half(15),
+                        Eigen::half(16), Eigen::half(13), Eigen::half(14),
+                        Eigen::half(23), Eigen::half(24), Eigen::half(21),
+                        Eigen::half(22), Eigen::half(19), Eigen::half(20)}));
+}
+
+// bfloat16 tests.
+TEST(ReverseOpTest, BFloat16OneDimension) {
+  ReverseOpModel<Eigen::bfloat16> model({TensorType_BFLOAT16, {4}},
+                                        {TensorType_INT32, {1}});
+  model.PopulateTensor<Eigen::bfloat16>(
+      model.input(), {Eigen::bfloat16(1), Eigen::bfloat16(2),
+                      Eigen::bfloat16(3), Eigen::bfloat16(4)});
+  model.PopulateTensor<int32_t>(model.axis(), {0});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4));
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAreArray({Eigen::bfloat16(4), Eigen::bfloat16(3),
+                                Eigen::bfloat16(2), Eigen::bfloat16(1)}));
+}
+
+TEST(ReverseOpTest, BFloat16MultiDimensions) {
+  ReverseOpModel<Eigen::bfloat16> model({TensorType_BFLOAT16, {4, 3, 2}},
+                                        {TensorType_INT32, {1}});
+  model.PopulateTensor<Eigen::bfloat16>(
+      model.input(),
+      {Eigen::bfloat16(1),  Eigen::bfloat16(2),  Eigen::bfloat16(3),
+       Eigen::bfloat16(4),  Eigen::bfloat16(5),  Eigen::bfloat16(6),
+       Eigen::bfloat16(7),  Eigen::bfloat16(8),  Eigen::bfloat16(9),
+       Eigen::bfloat16(10), Eigen::bfloat16(11), Eigen::bfloat16(12),
+       Eigen::bfloat16(13), Eigen::bfloat16(14), Eigen::bfloat16(15),
+       Eigen::bfloat16(16), Eigen::bfloat16(17), Eigen::bfloat16(18),
+       Eigen::bfloat16(19), Eigen::bfloat16(20), Eigen::bfloat16(21),
+       Eigen::bfloat16(22), Eigen::bfloat16(23), Eigen::bfloat16(24)});
+  model.PopulateTensor<int32_t>(model.axis(), {1});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutputShape(), ElementsAre(4, 3, 2));
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray(
+          {Eigen::bfloat16(5),  Eigen::bfloat16(6),  Eigen::bfloat16(3),
+           Eigen::bfloat16(4),  Eigen::bfloat16(1),  Eigen::bfloat16(2),
+           Eigen::bfloat16(11), Eigen::bfloat16(12), Eigen::bfloat16(9),
+           Eigen::bfloat16(10), Eigen::bfloat16(7),  Eigen::bfloat16(8),
+           Eigen::bfloat16(17), Eigen::bfloat16(18), Eigen::bfloat16(15),
+           Eigen::bfloat16(16), Eigen::bfloat16(13), Eigen::bfloat16(14),
+           Eigen::bfloat16(23), Eigen::bfloat16(24), Eigen::bfloat16(21),
+           Eigen::bfloat16(22), Eigen::bfloat16(19), Eigen::bfloat16(20)}));
+}
+
 }  // namespace
 }  // namespace tflite

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
* TfLite Reverse missing datatype support

 -Adds bf16, f16 support for reverse
 -Adds bf16, f16 reverse unit tests