### PR TITLE
TfLite Slice missing datatype support (#33)

### DIFF
--- a/tensorflow/lite/kernels/slice.cc
+++ b/tensorflow/lite/kernels/slice.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <string>
 #include <vector>
 
+#include "Eigen/Core"
 #include "tensorflow/lite/context_util.h"
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
@@ -253,6 +254,12 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       break;
     case kTfLiteString:
       TF_LITE_SLICE(string);
+      break;
+    case kTfLiteFloat16:
+      TF_LITE_SLICE(Eigen::half);
+      break;
+    case kTfLiteBFloat16:
+      TF_LITE_SLICE(Eigen::bfloat16);
       break;
     default:
       TF_LITE_KERNEL_LOG(

--- a/tensorflow/lite/kernels/slice_test.cc
+++ b/tensorflow/lite/kernels/slice_test.cc
@@ -19,6 +19,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "Eigen/Core"
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"
@@ -307,6 +308,74 @@ TEST_P(SliceOpTest, SliceBool) {
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
   EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 2}));
   EXPECT_THAT(m.GetOutput(), ElementsAreArray({false, true}));
+}
+
+TEST_P(SliceOpTest, SliceFloat16) {
+  SliceOpModel<Eigen::half, int32_t> m({3, 2, 3, 1}, {4}, {1, 0, 0, 0}, {4},
+                                       {2, 1, -1, 1}, TensorType_INT32,
+                                       TensorType_FLOAT16, GetParam());
+  m.SetInput({Eigen::half(1), Eigen::half(1), Eigen::half(1), Eigen::half(2),
+              Eigen::half(2), Eigen::half(2), Eigen::half(3), Eigen::half(3),
+              Eigen::half(3), Eigen::half(4), Eigen::half(4), Eigen::half(4),
+              Eigen::half(5), Eigen::half(5), Eigen::half(5), Eigen::half(6),
+              Eigen::half(6), Eigen::half(6)});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 1, 3, 1}));
+  EXPECT_THAT(
+      m.GetOutput(),
+      ElementsAreArray({Eigen::half(3), Eigen::half(3), Eigen::half(3),
+                        Eigen::half(5), Eigen::half(5), Eigen::half(5)}));
+}
+
+TEST_P(SliceOpTest, SliceBFloat16) {
+  SliceOpModel<Eigen::bfloat16, int32_t> m({3, 2, 3, 1}, {4}, {1, 0, 0, 0}, {4},
+                                           {2, 1, -1, 1}, TensorType_INT32,
+                                           TensorType_BFLOAT16, GetParam());
+  m.SetInput({Eigen::bfloat16(1), Eigen::bfloat16(1), Eigen::bfloat16(1),
+              Eigen::bfloat16(2), Eigen::bfloat16(2), Eigen::bfloat16(2),
+              Eigen::bfloat16(3), Eigen::bfloat16(3), Eigen::bfloat16(3),
+              Eigen::bfloat16(4), Eigen::bfloat16(4), Eigen::bfloat16(4),
+              Eigen::bfloat16(5), Eigen::bfloat16(5), Eigen::bfloat16(5),
+              Eigen::bfloat16(6), Eigen::bfloat16(6), Eigen::bfloat16(6)});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 1, 3, 1}));
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({Eigen::bfloat16(3), Eigen::bfloat16(3),
+                                Eigen::bfloat16(3), Eigen::bfloat16(5),
+                                Eigen::bfloat16(5), Eigen::bfloat16(5)}));
+}
+
+TEST_P(SliceOpTest, BeginNonZeroSizeMinus1Axis1Float16) {
+  SliceOpModel<Eigen::half, int32_t> m({3, 3, 2, 1}, {4}, {1, 1, 0, 0}, {4},
+                                       {2, -1, 1, 1}, TensorType_INT32,
+                                       TensorType_FLOAT16, GetParam());
+  m.SetInput({Eigen::half(1), Eigen::half(1), Eigen::half(2), Eigen::half(2),
+              Eigen::half(3), Eigen::half(3), Eigen::half(4), Eigen::half(4),
+              Eigen::half(5), Eigen::half(5), Eigen::half(6), Eigen::half(6),
+              Eigen::half(7), Eigen::half(7), Eigen::half(8), Eigen::half(8),
+              Eigen::half(9), Eigen::half(9)});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 1, 1}));
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({Eigen::half(5), Eigen::half(6), Eigen::half(8),
+                                Eigen::half(9)}));
+}
+
+TEST_P(SliceOpTest, BeginNonZeroSizeMinus1Axis1BFloat16) {
+  SliceOpModel<Eigen::bfloat16, int32_t> m({3, 3, 2, 1}, {4}, {1, 1, 0, 0}, {4},
+                                           {2, -1, 1, 1}, TensorType_INT32,
+                                           TensorType_BFLOAT16, GetParam());
+  m.SetInput({Eigen::bfloat16(1), Eigen::bfloat16(1), Eigen::bfloat16(2),
+              Eigen::bfloat16(2), Eigen::bfloat16(3), Eigen::bfloat16(3),
+              Eigen::bfloat16(4), Eigen::bfloat16(4), Eigen::bfloat16(5),
+              Eigen::bfloat16(5), Eigen::bfloat16(6), Eigen::bfloat16(6),
+              Eigen::bfloat16(7), Eigen::bfloat16(7), Eigen::bfloat16(8),
+              Eigen::bfloat16(8), Eigen::bfloat16(9), Eigen::bfloat16(9)});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 2, 1, 1}));
+  EXPECT_THAT(m.GetOutput(),
+              ElementsAreArray({Eigen::bfloat16(5), Eigen::bfloat16(6),
+                                Eigen::bfloat16(8), Eigen::bfloat16(9)}));
 }
 
 INSTANTIATE_TEST_SUITE_P(SliceOpTest, SliceOpTest,

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
* TfLite Slice missing datatype support

-Adds bf16, f16 support for slice
-Adds bf16, f16 slice unit tests