### PR TITLE
TfLite Pad missing datatype support (#50)

### DIFF
--- a/tensorflow/lite/kernels/pad.cc
+++ b/tensorflow/lite/kernels/pad.cc
@@ -330,6 +330,44 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
         }
       }
     } break;
+    case kTfLiteFloat16: {
+      Eigen::half pad_value =
+          op_context.constant_values == nullptr
+              ? static_cast<Eigen::half>(0.f)
+              : *GetTensorData<Eigen::half>(op_context.constant_values);
+      if (kernel_type == kReference) {
+        if (op_context.resizing_category == ResizingCategory::kImageStyle) {
+          TF_LITE_PAD(reference_ops, PadImageStyle, Eigen::half, pad_value);
+        } else {
+          TF_LITE_PAD(reference_ops, Pad, Eigen::half, pad_value);
+        }
+      } else if (kernel_type == kGenericOptimized) {
+        if (op_context.resizing_category == ResizingCategory::kImageStyle) {
+          TF_LITE_PAD(optimized_ops, PadImageStyle, Eigen::half, pad_value);
+        } else {
+          TF_LITE_PAD(optimized_ops, Pad, Eigen::half, pad_value);
+        }
+      }
+    } break;
+    case kTfLiteBFloat16: {
+      Eigen::bfloat16 pad_value =
+          op_context.constant_values == nullptr
+              ? static_cast<Eigen::bfloat16>(0.f)
+              : *GetTensorData<Eigen::bfloat16>(op_context.constant_values);
+      if (kernel_type == kReference) {
+        if (op_context.resizing_category == ResizingCategory::kImageStyle) {
+          TF_LITE_PAD(reference_ops, PadImageStyle, Eigen::bfloat16, pad_value);
+        } else {
+          TF_LITE_PAD(reference_ops, Pad, Eigen::bfloat16, pad_value);
+        }
+      } else if (kernel_type == kGenericOptimized) {
+        if (op_context.resizing_category == ResizingCategory::kImageStyle) {
+          TF_LITE_PAD(optimized_ops, PadImageStyle, Eigen::bfloat16, pad_value);
+        } else {
+          TF_LITE_PAD(optimized_ops, Pad, Eigen::bfloat16, pad_value);
+        }
+      }
+    } break;
     case kTfLiteUInt8: {
       EvalInt<uint8_t>(context, op_context, op_params);
     } break;

--- a/tensorflow/lite/kernels/pad_test.cc
+++ b/tensorflow/lite/kernels/pad_test.cc
@@ -772,6 +772,53 @@ TEST_F(PadV2OpTest, Int64PaddingSimpleConstFloat32ValuedTestInt8) {
 }
 
 template <typename padding_integer_type>
+void SimpleConstFloat16ValuedTest() {
+  PadV2OpConstModel<Eigen::half, padding_integer_type> m(
+      {TensorType_FLOAT16, {1, 2, 2, 1}}, {4, 2}, {0, 0, 1, 1, 1, 1, 0, 0},
+      Eigen::half{4.0f}, {TensorType_FLOAT16});
+  m.SetInput({Eigen::half{1.5f}, Eigen::half{2.5f}, Eigen::half{3.5f},
+              Eigen::half{4.5}});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(
+      m.GetOutput(),
+      ElementsAreArray(ArrayFloatNear(
+          {Eigen::half{4}, Eigen::half{4}, Eigen::half{4}, Eigen::half{4},
+           Eigen::half{4}, Eigen::half{1.5}, Eigen::half{2.5}, Eigen::half{4},
+           Eigen::half{4}, Eigen::half{3.5}, Eigen::half{4.5}, Eigen::half{4},
+           Eigen::half{4}, Eigen::half{4}, Eigen::half{4}, Eigen::half{4}})));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 4, 4, 1}));
+}
+
+TEST_F(PadV2OpTest, Int32PaddingSimpleConstFloat16) {
+  SimpleConstFloat16ValuedTest<int32_t>();
+}
+
+TEST_F(PadV2OpTest, Int64PaddingSimpleConstFloat16) {
+  SimpleConstFloat16ValuedTest<int64_t>();
+}
+
+template <typename padding_integer_type>
+void SimpleConstBFloat16ValuedTest() {
+  PadV2OpConstModel<Eigen::bfloat16, padding_integer_type> m(
+      {TensorType_BFLOAT16, {1, 2, 2, 1}}, {4, 2}, {0, 0, 1, 1, 1, 1, 0, 0},
+      Eigen::bfloat16{6.0f}, {TensorType_BFLOAT16});
+  m.SetInput({Eigen::bfloat16{1.0f}, Eigen::bfloat16{2.0f},
+              Eigen::bfloat16{3.0f}, Eigen::bfloat16{4.0}});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({6, 6, 6, 6, 6, 1, 2, 6, 6, 3, 4,
+                                               6, 6, 6, 6, 6}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 4, 4, 1}));
+}
+
+TEST_F(PadV2OpTest, Int32PaddingSimpleConstBFloat16) {
+  SimpleConstBFloat16ValuedTest<int32_t>();
+}
+
+TEST_F(PadV2OpTest, Int64PaddingSimpleConstBFloat16) {
+  SimpleConstBFloat16ValuedTest<int64_t>();
+}
+
+template <typename padding_integer_type>
 void Simple4DConstFloat32ValuedTest() {
   // Padding is represented as four 2-D lists representing above padding and
   // below padding (i.e. {{0, 0}, {1, 1}, {1, 1}, {0, 0}}).
@@ -790,6 +837,49 @@ TEST_F(PadV2OpTest, Int32PaddingSimple4DConstFloat32ValuedTest) {
 
 TEST_F(PadV2OpTest, Int64PaddingSimple4DConstFloat32ValuedTest) {
   Simple4DConstFloat32ValuedTest<int64_t>();
+}
+
+template <typename padding_integer_type>
+void Simple4DConstFloat16ValuedTest() {
+  PadV2OpConstModel<Eigen::half, padding_integer_type> m(
+      {TensorType_FLOAT16, {1, 1, 2, 1}}, {4, 2}, {0, 1, 0, 0, 0, 0, 0, 1},
+      Eigen::half{7.0}, {TensorType_FLOAT16});
+  m.SetInput({Eigen::half{3.0f}, Eigen::half{6.0f}});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({3, 7, 6, 7, 7, 7, 7, 7}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 1, 2, 2}));
+}
+
+TEST_F(PadV2OpTest, Int32PaddingSimple4DConstFloat16ValuedTest) {
+  Simple4DConstFloat16ValuedTest<int32_t>();
+}
+
+TEST_F(PadV2OpTest, Int64PaddingSimple4DConstFloat16ValuedTest) {
+  Simple4DConstFloat16ValuedTest<int64_t>();
+}
+
+template <typename padding_integer_type>
+void Simple4DConstBFloat16ValuedTest() {
+  PadV2OpConstModel<Eigen::bfloat16, padding_integer_type> m(
+      {TensorType_BFLOAT16, {1, 1, 2, 1}}, {4, 2}, {0, 1, 0, 0, 0, 0, 0, 1},
+      Eigen::bfloat16{5.0}, {TensorType_BFLOAT16});
+  m.SetInput({Eigen::bfloat16{3.2f}, Eigen::bfloat16{6.4f}});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(
+      m.GetOutput(),
+      ElementsAreArray(ArrayFloatNear(
+          {Eigen::bfloat16{3.2f}, Eigen::bfloat16{5.0f}, Eigen::bfloat16{6.4f},
+           Eigen::bfloat16{5.0f}, Eigen::bfloat16{5.0f}, Eigen::bfloat16{5.0f},
+           Eigen::bfloat16{5.0f}, Eigen::bfloat16{5.0f}})));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({2, 1, 2, 2}));
+}
+
+TEST_F(PadV2OpTest, Int32PaddingSimple4DConstBFloat16ValuedTest) {
+  Simple4DConstBFloat16ValuedTest<int32_t>();
+}
+
+TEST_F(PadV2OpTest, Int64PaddingSimple4DConstBFloat16ValuedTest) {
+  Simple4DConstBFloat16ValuedTest<int64_t>();
 }
 
 template <typename padding_integer_type>
@@ -832,6 +922,50 @@ TEST_F(PadV2OpTest, Int32PaddingSimpleDynamicTest) {
 
 TEST_F(PadV2OpTest, Int64PaddingSimpleDynamicTest) {
   SimpleDynamicTestV2<int64_t>();
+}
+
+template <typename padding_integer_type>
+void SimpleDynamicTestV2Float16() {
+  PadV2OpDynamicModel<Eigen::half, padding_integer_type> m(
+      {TensorType_FLOAT16, {1, 2, 2, 1}}, {4, 2}, Eigen::half{0.0},
+      {TensorType_FLOAT16});
+  m.SetInput({Eigen::half{1.0f}, Eigen::half{2.0f}, Eigen::half{3.0f},
+              Eigen::half{4.0f}});
+  m.SetPaddings({0, 0, 1, 1, 1, 1, 0, 0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({0, 0, 0, 0, 0, 1, 2, 0, 0, 3, 4,
+                                               0, 0, 0, 0, 0}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 4, 4, 1}));
+}
+
+TEST_F(PadV2OpTest, Int32PaddingSimpleDynamicTestFloat16) {
+  SimpleDynamicTestV2Float16<int32_t>();
+}
+
+TEST_F(PadV2OpTest, Int64PaddingSimpleDynamicTestFloat16) {
+  SimpleDynamicTestV2Float16<int64_t>();
+}
+
+template <typename padding_integer_type>
+void SimpleDynamicTestV2BFloat16() {
+  PadV2OpDynamicModel<Eigen::bfloat16, padding_integer_type> m(
+      {TensorType_BFLOAT16, {1, 2, 2, 1}}, {4, 2}, Eigen::bfloat16{2.0},
+      {TensorType_BFLOAT16});
+  m.SetInput({Eigen::bfloat16{5.0f}, Eigen::bfloat16{6.0f},
+              Eigen::bfloat16{7.0f}, Eigen::bfloat16{8.0f}});
+  m.SetPaddings({0, 0, 1, 1, 1, 1, 0, 0});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput(), ElementsAreArray({2, 2, 2, 2, 2, 5, 6, 2, 2, 7, 8,
+                                               2, 2, 2, 2, 2}));
+  EXPECT_THAT(m.GetOutputShape(), ElementsAreArray({1, 4, 4, 1}));
+}
+
+TEST_F(PadV2OpTest, Int32PaddingSimpleDynamicTestBFloat16) {
+  SimpleDynamicTestV2BFloat16<int32_t>();
+}
+
+TEST_F(PadV2OpTest, Int64PaddingSimpleDynamicTestBFloat16) {
+  SimpleDynamicTestV2BFloat16<int64_t>();
 }
 
 template <typename padding_integer_type>

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:
@@ -1163,6 +1168,7 @@ TFLITE_TENSOR_TYPE_ASSOC(uint32_t, TensorType_UINT32);
 TFLITE_TENSOR_TYPE_ASSOC(uint64_t, TensorType_UINT64);
 TFLITE_TENSOR_TYPE_ASSOC(TfLiteFloat16, TensorType_FLOAT16);
 TFLITE_TENSOR_TYPE_ASSOC(Eigen::half, TensorType_FLOAT16);
+TFLITE_TENSOR_TYPE_ASSOC(Eigen::bfloat16, TensorType_BFLOAT16);
 TFLITE_TENSOR_TYPE_ASSOC(float, TensorType_FLOAT32);
 TFLITE_TENSOR_TYPE_ASSOC(double, TensorType_FLOAT64);
 TFLITE_TENSOR_TYPE_ASSOC(std::string, TensorType_STRING);


### PR DESCRIPTION
-Adds bf16, f16 support for pad
-Adds bf16, f16 pad unit tests