### PR TITLE
Tflite min max missing datatypes support (#38)

### DIFF
--- a/tensorflow/lite/kernels/maximum_minimum.cc
+++ b/tensorflow/lite/kernels/maximum_minimum.cc
@@ -16,6 +16,7 @@ limitations under the License.
 
 #include <stdint.h>
 
+#include "Eigen/Core"
 #include "tensorflow/lite/core/c/common.h"
 #include "tensorflow/lite/kernels/internal/compatibility.h"
 #include "tensorflow/lite/kernels/internal/optimized/optimized_ops.h"
@@ -243,6 +244,14 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
       break;
     case kTfLiteInt16:
       TFLiteOperation<kernel_type, int16_t, OpType>(context, node, op_context);
+      break;
+    case kTfLiteFloat16:
+      TFLiteOperation<kernel_type, Eigen::half, OpType>(context, node,
+                                                        op_context);
+      break;
+    case kTfLiteBFloat16:
+      TFLiteOperation<kernel_type, Eigen::bfloat16, OpType>(context, node,
+                                                            op_context);
       break;
     default:
       TF_LITE_KERNEL_LOG(context,

--- a/tensorflow/lite/kernels/maximum_minimum_test.cc
+++ b/tensorflow/lite/kernels/maximum_minimum_test.cc
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "Eigen/Core"
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
@@ -240,5 +241,126 @@ TEST(MaximumOpTest, Int32WithBroadcastTest5D) {
       {TensorType_INT32, {1}}, {TensorType_INT32, {3, 1, 2, 1, 1}}, data1,
       data2, {1, 0, -1, -2, 2, 2});
 }
+
+TEST(MaximumOpTest, Float16Test) {
+  std::initializer_list<Eigen::half> data1 = {
+      Eigen::half(1.0),  Eigen::half(0.0),  Eigen::half(-1.0),
+      Eigen::half(11.0), Eigen::half(-2.0), Eigen::half(-1.44)};
+  std::initializer_list<Eigen::half> data2 = {
+      Eigen::half(-1.0), Eigen::half(0.0),  Eigen::half(1.0),
+      Eigen::half(12.0), Eigen::half(-3.0), Eigen::half(-1.43)};
+  TestModel<Eigen::half>(
+      BuiltinOperator_MAXIMUM, {TensorType_FLOAT16, {3, 1, 2}},
+      {TensorType_FLOAT16, {3, 1, 2}}, {TensorType_FLOAT16, {3, 1, 2}}, data1,
+      data2,
+      {Eigen::half(1.0), Eigen::half(0.0), Eigen::half(1.0), Eigen::half(12.0),
+       Eigen::half(-2.0), Eigen::half(-1.43)});
+  TestModel<Eigen::half>(
+      BuiltinOperator_MINIMUM, {TensorType_FLOAT16, {3, 1, 2}},
+      {TensorType_FLOAT16, {3, 1, 2}}, {TensorType_FLOAT16, {3, 1, 2}}, data1,
+      data2,
+      {Eigen::half(-1.0), Eigen::half(0.0), Eigen::half(-1.0),
+       Eigen::half(11.0), Eigen::half(-3.0), Eigen::half(-1.44)});
+}
+
+TEST(MaximumOpTest, BFloat16Test) {
+  std::initializer_list<Eigen::bfloat16> data1 = {
+      Eigen::bfloat16(1.0),  Eigen::bfloat16(0.0),  Eigen::bfloat16(-1.0),
+      Eigen::bfloat16(11.0), Eigen::bfloat16(-2.0), Eigen::bfloat16(-1.44)};
+  std::initializer_list<Eigen::bfloat16> data2 = {
+      Eigen::bfloat16(-1.0), Eigen::bfloat16(0.0),  Eigen::bfloat16(1.0),
+      Eigen::bfloat16(12.0), Eigen::bfloat16(-3.0), Eigen::bfloat16(-1.43)};
+  TestModel<Eigen::bfloat16>(
+      BuiltinOperator_MAXIMUM, {TensorType_BFLOAT16, {3, 1, 2}},
+      {TensorType_BFLOAT16, {3, 1, 2}}, {TensorType_BFLOAT16, {3, 1, 2}}, data1,
+      data2,
+      {Eigen::bfloat16(1.0), Eigen::bfloat16(0.0), Eigen::bfloat16(1.0),
+       Eigen::bfloat16(12.0), Eigen::bfloat16(-2.0), Eigen::bfloat16(-1.43)});
+  TestModel<Eigen::bfloat16>(
+      BuiltinOperator_MINIMUM, {TensorType_BFLOAT16, {3, 1, 2}},
+      {TensorType_BFLOAT16, {3, 1, 2}}, {TensorType_BFLOAT16, {3, 1, 2}}, data1,
+      data2,
+      {Eigen::bfloat16(-1.0), Eigen::bfloat16(0.0), Eigen::bfloat16(-1.0),
+       Eigen::bfloat16(11.0), Eigen::bfloat16(-3.0), Eigen::bfloat16(-1.44)});
+}
+
+TEST(MaximumOpTest, BFloat16WithBroadcastTest5DScalarY) {
+  std::initializer_list<Eigen::bfloat16> data1 = {
+      Eigen::bfloat16(1.0),  Eigen::bfloat16(0.0), Eigen::bfloat16(-1.0),
+      Eigen::bfloat16(-2.0), Eigen::bfloat16(3.0), Eigen::bfloat16(11.0)};
+  std::initializer_list<Eigen::bfloat16> data2 = {Eigen::bfloat16(2.0)};
+  TestModel<Eigen::bfloat16>(
+      BuiltinOperator_MAXIMUM, {TensorType_BFLOAT16, {3, 1, 2, 1, 1}},
+      {TensorType_BFLOAT16, {1}}, {TensorType_BFLOAT16, {3, 1, 2, 1, 1}}, data1,
+      data2,
+      {Eigen::bfloat16(2.0), Eigen::bfloat16(2.0), Eigen::bfloat16(2.0),
+       Eigen::bfloat16(2.0), Eigen::bfloat16(3.0), Eigen::bfloat16(11.0)});
+  TestModel<Eigen::bfloat16>(
+      BuiltinOperator_MINIMUM, {TensorType_BFLOAT16, {3, 1, 2, 1, 1}},
+      {TensorType_BFLOAT16, {1}}, {TensorType_BFLOAT16, {3, 1, 2, 1, 1}}, data1,
+      data2,
+      {Eigen::bfloat16(1.0), Eigen::bfloat16(0.0), Eigen::bfloat16(-1.0),
+       Eigen::bfloat16(-2.0), Eigen::bfloat16(2.0), Eigen::bfloat16(2.0)});
+}
+
+TEST(MaximumOpTest, Float16WithBroadcastTest5DScalarY) {
+  std::initializer_list<Eigen::half> data1 = {
+      Eigen::half(1.0),  Eigen::half(0.0), Eigen::half(-1.0),
+      Eigen::half(-2.0), Eigen::half(3.0), Eigen::half(11.0)};
+  std::initializer_list<Eigen::half> data2 = {Eigen::half(2.0)};
+  TestModel<Eigen::half>(
+      BuiltinOperator_MAXIMUM, {TensorType_FLOAT16, {3, 1, 2, 1, 1}},
+      {TensorType_FLOAT16, {1}}, {TensorType_FLOAT16, {3, 1, 2, 1, 1}}, data1,
+      data2,
+      {Eigen::half(2.0), Eigen::half(2.0), Eigen::half(2.0), Eigen::half(2.0),
+       Eigen::half(3.0), Eigen::half(11.0)});
+  TestModel<Eigen::half>(
+      BuiltinOperator_MINIMUM, {TensorType_FLOAT16, {3, 1, 2, 1, 1}},
+      {TensorType_FLOAT16, {1}}, {TensorType_FLOAT16, {3, 1, 2, 1, 1}}, data1,
+      data2,
+      {Eigen::half(1.0), Eigen::half(0.0), Eigen::half(-1.0), Eigen::half(-2.0),
+       Eigen::half(2.0), Eigen::half(2.0)});
+}
+
+TEST(MaximumOpTest, Float16WithBroadcastTest5D) {
+  std::initializer_list<Eigen::half> data1 = {
+      Eigen::half(1.0),  Eigen::half(0.0),   Eigen::half(-1.0),
+      Eigen::half(-2.0), Eigen::half(-1.44), Eigen::half(11.0)};
+  std::initializer_list<Eigen::half> data2 = {Eigen::half(0.5),
+                                              Eigen::half(2.0)};
+  TestModel<Eigen::half>(
+      BuiltinOperator_MAXIMUM, {TensorType_FLOAT16, {3, 1, 1, 1, 2}},
+      {TensorType_FLOAT16, {2}}, {TensorType_FLOAT16, {3, 1, 1, 1, 2}}, data1,
+      data2,
+      {Eigen::half(1.0), Eigen::half(2.0), Eigen::half(0.5), Eigen::half(2.0),
+       Eigen::half(0.5), Eigen::half(11.0)});
+  TestModel<Eigen::half>(
+      BuiltinOperator_MINIMUM, {TensorType_FLOAT16, {3, 1, 1, 1, 2}},
+      {TensorType_FLOAT16, {2}}, {TensorType_FLOAT16, {3, 1, 1, 1, 2}}, data1,
+      data2,
+      {Eigen::half(0.5), Eigen::half(0.0), Eigen::half(-1.0), Eigen::half(-2.0),
+       Eigen::half(-1.44), Eigen::half(2.0)});
+}
+
+TEST(MaximumOpTest, BFloat16WithBroadcastTest5D) {
+  std::initializer_list<Eigen::bfloat16> data1 = {
+      Eigen::bfloat16(1.0),  Eigen::bfloat16(0.0),   Eigen::bfloat16(-1.0),
+      Eigen::bfloat16(-2.0), Eigen::bfloat16(-1.44), Eigen::bfloat16(11.0)};
+  std::initializer_list<Eigen::bfloat16> data2 = {Eigen::bfloat16(0.5),
+                                                  Eigen::bfloat16(2.0)};
+  TestModel<Eigen::bfloat16>(
+      BuiltinOperator_MAXIMUM, {TensorType_BFLOAT16, {3, 1, 1, 1, 2}},
+      {TensorType_BFLOAT16, {2}}, {TensorType_BFLOAT16, {3, 1, 1, 1, 2}}, data1,
+      data2,
+      {Eigen::bfloat16(1.0), Eigen::bfloat16(2.0), Eigen::bfloat16(0.5),
+       Eigen::bfloat16(2.0), Eigen::bfloat16(0.5), Eigen::bfloat16(11.0)});
+  TestModel<Eigen::bfloat16>(
+      BuiltinOperator_MINIMUM, {TensorType_BFLOAT16, {3, 1, 1, 1, 2}},
+      {TensorType_BFLOAT16, {2}}, {TensorType_BFLOAT16, {3, 1, 1, 1, 2}}, data1,
+      data2,
+      {Eigen::bfloat16(0.5), Eigen::bfloat16(0.0), Eigen::bfloat16(-1.0),
+       Eigen::bfloat16(-2.0), Eigen::bfloat16(-1.44), Eigen::bfloat16(2.0)});
+}
+
 }  // namespace
 }  // namespace tflite

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
-Adds bf16,f16 for tflite min max operations
-Adds bf16,f16 min max unit tests