### PR TITLE
TfLite Round missing datatype support (#32)

### DIFF
--- a/tensorflow/lite/kernels/internal/reference/round.h
+++ b/tensorflow/lite/kernels/internal/reference/round.h
@@ -34,15 +34,16 @@ inline float RoundToNearest(float value) {
   }
 }
 
-inline void Round(const RuntimeShape& input_shape, const float* input_data,
-                  const RuntimeShape& output_shape, float* output_data) {
+template <typename Scalar>
+inline void Round(const RuntimeShape& input_shape, const Scalar* input_data,
+                  const RuntimeShape& output_shape, Scalar* output_data) {
   const int flat_size = MatchingFlatSize(input_shape, output_shape);
   for (int i = 0; i < flat_size; ++i) {
     // Note that this implementation matches that of tensorFlow tf.round
     // and corresponds to the bankers rounding method.
     // cfenv (for fesetround) is not yet supported universally on Android, so
     // using a work around.
-    output_data[i] = RoundToNearest(input_data[i]);
+    output_data[i] = static_cast<Scalar>(RoundToNearest(input_data[i]));
   }
 }
 

--- a/tensorflow/lite/kernels/round_test.cc
+++ b/tensorflow/lite/kernels/round_test.cc
@@ -17,6 +17,7 @@ limitations under the License.
 #include <vector>
 
 #include <gtest/gtest.h>
+#include "Eigen/Core"
 #include "tensorflow/lite/kernels/test_util.h"
 #include "tensorflow/lite/schema/schema_generated.h"
 
@@ -25,11 +26,12 @@ namespace {
 
 using ::testing::ElementsAreArray;
 
+template <typename T>
 class RoundOpModel : public SingleOpModel {
  public:
-  RoundOpModel(std::initializer_list<int> input_shape, TensorType input_type) {
-    input_ = AddInput(TensorType_FLOAT32);
-    output_ = AddOutput(TensorType_FLOAT32);
+  RoundOpModel(std::initializer_list<int> input_shape) {
+    input_ = AddInput(GetTensorType<T>());
+    output_ = AddOutput(GetTensorType<T>());
     SetBuiltinOp(BuiltinOperator_ROUND, BuiltinOptions_NONE, 0);
     BuildInterpreter({
         input_shape,
@@ -38,7 +40,7 @@ class RoundOpModel : public SingleOpModel {
 
   int input() { return input_; }
 
-  std::vector<float> GetOutput() { return ExtractVector<float>(output_); }
+  std::vector<T> GetOutput() { return ExtractVector<T>(output_); }
   std::vector<int> GetOutputShape() { return GetTensorShape(output_); }
 
  private:
@@ -47,7 +49,7 @@ class RoundOpModel : public SingleOpModel {
 };
 
 TEST(RoundOpTest, SingleDim) {
-  RoundOpModel model({6}, TensorType_FLOAT32);
+  RoundOpModel<float> model({6});
   model.PopulateTensor<float>(model.input(), {8.5, 0.0, 3.5, 4.2, -3.5, -4.5});
   ASSERT_EQ(model.Invoke(), kTfLiteOk);
   EXPECT_THAT(model.GetOutput(), ElementsAreArray({8, 0, 4, 4, -4, -4}));
@@ -55,13 +57,78 @@ TEST(RoundOpTest, SingleDim) {
 }
 
 TEST(RoundOpTest, MultiDims) {
-  RoundOpModel model({2, 1, 1, 6}, TensorType_FLOAT32);
+  RoundOpModel<float> model({2, 1, 1, 6});
   model.PopulateTensor<float>(
       model.input(), {0.0001, 8.0001, 0.9999, 9.9999, 0.5, -0.0001, -8.0001,
                       -0.9999, -9.9999, -0.5, -2.5, 1.5});
   ASSERT_EQ(model.Invoke(), kTfLiteOk);
   EXPECT_THAT(model.GetOutput(),
               ElementsAreArray({0, 8, 1, 10, 0, 0, -8, -1, -10, -0, -2, 2}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 1, 1, 6}));
+}
+
+TEST(RoundOpTest, Float16SingleDim) {
+  RoundOpModel<Eigen::half> model({6});
+  model.PopulateTensor<Eigen::half>(
+      model.input(), {Eigen::half(8.5), Eigen::half(0.0), Eigen::half(3.5),
+                      Eigen::half(4.2), Eigen::half(-3.5), Eigen::half(-4.5)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({Eigen::half(8), Eigen::half(0), Eigen::half(4),
+                        Eigen::half(4), Eigen::half(-4), Eigen::half(-4)}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({6}));
+}
+
+TEST(RoundOpTest, Float16MultiDims) {
+  RoundOpModel<Eigen::half> model({2, 1, 1, 6});
+  model.PopulateTensor<Eigen::half>(
+      model.input(),
+      {Eigen::half(0.0001), Eigen::half(8.0001), Eigen::half(0.9999),
+       Eigen::half(9.9999), Eigen::half(0.5), Eigen::half(-0.0001),
+       Eigen::half(-8.0001), Eigen::half(-0.9999), Eigen::half(-9.9999),
+       Eigen::half(-0.5), Eigen::half(-2.5), Eigen::half(1.5)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray({Eigen::half(0), Eigen::half(8), Eigen::half(1),
+                        Eigen::half(10), Eigen::half(0), Eigen::half(0),
+                        Eigen::half(-8), Eigen::half(-1), Eigen::half(-10),
+                        Eigen::half(-0), Eigen::half(-2), Eigen::half(2)}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 1, 1, 6}));
+}
+
+TEST(RoundOpTest, BFloat16SingleDim) {
+  RoundOpModel<Eigen::bfloat16> model({6});
+  model.PopulateTensor<Eigen::bfloat16>(
+      model.input(),
+      {Eigen::bfloat16(8.5), Eigen::bfloat16(0.0), Eigen::bfloat16(3.5),
+       Eigen::bfloat16(4.2), Eigen::bfloat16(-3.5), Eigen::bfloat16(-4.5)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutput(),
+              ElementsAreArray({Eigen::bfloat16(8), Eigen::bfloat16(0),
+                                Eigen::bfloat16(4), Eigen::bfloat16(4),
+                                Eigen::bfloat16(-4), Eigen::bfloat16(-4)}));
+  EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({6}));
+}
+
+TEST(RoundOpTest, BFloat16MultiDims) {
+  RoundOpModel<Eigen::bfloat16> model({2, 1, 1, 6});
+  model.PopulateTensor<Eigen::bfloat16>(
+      model.input(),
+      {Eigen::bfloat16(0.0001), Eigen::bfloat16(8.0001),
+       Eigen::bfloat16(0.9999), Eigen::bfloat16(9.9999), Eigen::bfloat16(0.5),
+       Eigen::bfloat16(-0.0001), Eigen::bfloat16(-8.0001),
+       Eigen::bfloat16(-0.9999), Eigen::bfloat16(-9.9999),
+       Eigen::bfloat16(-0.5), Eigen::bfloat16(-2.5), Eigen::bfloat16(1.5)});
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(
+      model.GetOutput(),
+      ElementsAreArray(
+          {Eigen::bfloat16(0), Eigen::bfloat16(8), Eigen::bfloat16(1),
+           Eigen::bfloat16(10), Eigen::bfloat16(0), Eigen::bfloat16(0),
+           Eigen::bfloat16(-8), Eigen::bfloat16(-1), Eigen::bfloat16(-10),
+           Eigen::bfloat16(-0), Eigen::bfloat16(-2), Eigen::bfloat16(2)}));
   EXPECT_THAT(model.GetOutputShape(), ElementsAreArray({2, 1, 1, 6}));
 }
 

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:
@@ -1166,6 +1171,7 @@ TFLITE_TENSOR_TYPE_ASSOC(Eigen::half, TensorType_FLOAT16);
 TFLITE_TENSOR_TYPE_ASSOC(float, TensorType_FLOAT32);
 TFLITE_TENSOR_TYPE_ASSOC(double, TensorType_FLOAT64);
 TFLITE_TENSOR_TYPE_ASSOC(std::string, TensorType_STRING);
+TFLITE_TENSOR_TYPE_ASSOC(Eigen::bfloat16, TensorType_BFLOAT16);
 
 #undef TFLITE_TENSOR_TYPE_ASSOC
 


### PR DESCRIPTION
* TfLite Round missing datatype support

-Adds bf16, f16 support for round
-Adds bf16, f16 round unit tests