### PR TITLE
TfLite neg_op add type support

### DIFF
--- a/tensorflow/lite/kernels/neg.cc
+++ b/tensorflow/lite/kernels/neg.cc
@@ -67,6 +67,26 @@ TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
                             GetTensorShape(output),
                             GetTensorData<float>(output));
       break;
+    case kTfLiteInt8:
+      reference_ops::Negate(GetTensorShape(input), GetTensorData<int8_t>(input),
+                            GetTensorShape(output),
+                            GetTensorData<int8_t>(output));
+      break;
+    case kTfLiteInt16:
+      reference_ops::Negate(
+          GetTensorShape(input), GetTensorData<int16_t>(input),
+          GetTensorShape(output), GetTensorData<int16_t>(output));
+      break;
+    case kTfLiteFloat16:
+      reference_ops::Negate(
+          GetTensorShape(input), GetTensorData<Eigen::half>(input),
+          GetTensorShape(output), GetTensorData<Eigen::half>(output));
+      break;
+    case kTfLiteBFloat16:
+      reference_ops::Negate(
+          GetTensorShape(input), GetTensorData<Eigen::half>(input),
+          GetTensorShape(output), GetTensorData<Eigen::half>(output));
+      break;
     default:
       TF_LITE_KERNEL_LOG(
           context,

--- a/tensorflow/lite/kernels/neg_test.cc
+++ b/tensorflow/lite/kernels/neg_test.cc
@@ -48,17 +48,45 @@ class NegOpModel : public SingleOpModel {
     return ExtractVector<T>(output_);
   }
 
+  int input() const { return input_; }
+  int output() const { return output_; }
+
  protected:
   int input_;
   int output_;
 };
 
-TEST(NegOpModel, NegFloat) {
+TEST(NegOpModel, NegFloat32) {
   NegOpModel m({TensorType_FLOAT32, {2, 3}}, {TensorType_FLOAT32, {2, 3}});
   m.SetInput<float>({-2.0f, -1.0f, 0.f, 1.0f, 2.0f, 3.0f});
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
   EXPECT_THAT(m.GetOutput<float>(),
               ElementsAreArray({2.0f, 1.0f, 0.f, -1.0f, -2.0f, -3.0f}));
+}
+
+TEST(NegOpModel, NegFloat16) {
+  NegOpModel m({TensorType_FLOAT16, {6}}, {TensorType_FLOAT16, {6}});
+  m.SetInput<Eigen::half>({Eigen::half(-2.0f), Eigen::half(-1.0f),
+                           Eigen::half(0.f), Eigen::half(1.0f),
+                           Eigen::half(2.0f), Eigen::half(3.0f)});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetOutput<Eigen::half>(),
+              ElementsAreArray({Eigen::half(2.0f), Eigen::half(1.0f),
+                                Eigen::half(0.f), Eigen::half(-1.0f),
+                                Eigen::half(-2.0f), Eigen::half(-3.0f)}));
+}
+
+TEST(NegOpModel, NegBfloat16) {
+  NegOpModel m({TensorType_BFLOAT16, {6}}, {TensorType_BFLOAT16, {6}});
+  m.SetInput<Eigen::bfloat16>({Eigen::bfloat16(-2.0f), Eigen::bfloat16(-1.0f),
+                               Eigen::bfloat16(0.f), Eigen::bfloat16(1.0f),
+                               Eigen::bfloat16(2.0f), Eigen::bfloat16(3.0f)});
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(
+      m.GetOutput<Eigen::bfloat16>(),
+      ElementsAreArray({Eigen::bfloat16(2.0f), Eigen::bfloat16(1.0f),
+                        Eigen::bfloat16(0.f), Eigen::bfloat16(-1.0f),
+                        Eigen::bfloat16(-2.0f), Eigen::bfloat16(-3.0f)}));
 }
 
 TEST(NegOpModel, NegInt32) {
@@ -73,6 +101,62 @@ TEST(NegOpModel, NegInt64) {
   m.SetInput<int64_t>({-2, -1, 0, 1, 2, 3});
   ASSERT_EQ(m.Invoke(), kTfLiteOk);
   EXPECT_THAT(m.GetOutput<int64_t>(), ElementsAreArray({2, 1, 0, -1, -2, -3}));
+}
+
+class NegOpQuantizedModel : public NegOpModel {
+ public:
+  NegOpQuantizedModel(const TensorData& input, const TensorData& output)
+      : NegOpModel(SymmetricInt16Scaling(std::move(input)),
+                   SymmetricInt16Scaling(std::move(output))) {}
+
+  template <typename integer_dtype>
+  std::vector<float> GetDequantizedOutput() {
+    return Dequantize<integer_dtype>(ExtractVector<integer_dtype>(output_),
+                                     GetScale(output_), GetZeroPoint(output_));
+  }
+
+ private:
+  TensorData SymmetricInt16Scaling(TensorData tensor) {
+    if (tensor.type == TensorType_INT16) {
+      CHECK_EQ(std::abs(tensor.min), tensor.max);
+      tensor.scale = tensor.max / std::numeric_limits<int16_t>::max();
+      tensor.zero_point = 0;
+      tensor.min = 0;
+      tensor.max = 0;
+    }
+    return tensor;
+  }
+};
+
+template <typename T>
+float GetTolerance(float min, float max) {
+  const float kQuantizedStep =
+      2.0 * (max - min) /
+      (std::numeric_limits<T>::max() - std::numeric_limits<T>::min());
+  return kQuantizedStep;
+}
+
+template <TensorType tensor_type, typename integer_dtype>
+void QuantizedTests() {
+  const float kQuantizedTolerance = GetTolerance<integer_dtype>(-128.0, 128.0);
+  const std::vector<float> input = {-128.0f, -9, 0, 8, 127};
+  const std::vector<float> result = {128.0f, 9, 0, -8, -127};
+
+  NegOpQuantizedModel m({tensor_type, {5}, -128.0, 128.0},
+                        {tensor_type, {5}, -128.0, 128.0});
+
+  m.QuantizeAndPopulate<integer_dtype>(m.input(), input);
+  ASSERT_EQ(m.Invoke(), kTfLiteOk);
+  EXPECT_THAT(m.GetDequantizedOutput<integer_dtype>(),
+              ElementsAreArray(ArrayFloatNear(result, kQuantizedTolerance)));
+}
+
+TEST(NegOpQuantizedModel, NegInt8) {
+  QuantizedTests<TensorType_INT8, int8_t>();
+}
+
+TEST(NegOpQuantizedModel, NegInt16) {
+  QuantizedTests<TensorType_INT16, int16_t>();
 }
 
 }  // namespace

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
* TfLite neg_op add type support -Adds type support for bfloat16 -Adds type supoort for float16 -Adds type support for Int8 -Adds type support for Int16