### PR TITLE
Adds Stablehlo Batch Norm Training Op with Multiplier and Shift

### DIFF
--- a/tensorflow/compiler/mlir/lite/schema/schema.fbs
+++ b/tensorflow/compiler/mlir/lite/schema/schema.fbs
@@ -472,6 +472,7 @@ enum BuiltinOperator : int32 {
   STABLEHLO_RNG_BIT_GENERATOR = 204,
   REDUCE_WINDOW = 205 (deprecated),
   STABLEHLO_COMPOSITE = 206, // WARNING: No runtime support
+  STABLEHLO_BATCH_NORM_TRAINING = 215,
 }
 // LINT.ThenChange(nnapi_linter/linter.proto)
 
@@ -630,6 +631,7 @@ union BuiltinOptions2{
   StablehloRngBitGeneratorOptions,
   ReduceWindowOptions (deprecated),
   StableHLOCompositeOptions,
+  StablehloBatchNormTrainingOptions,
 }
 
 table StablehloGatherOptions{
@@ -1495,6 +1497,11 @@ table StableHLOCompositeOptions {
   composite_attributes:[ubyte];
   composite_attributes_format:CustomOptionsFormat;
   version:int32;
+}
+
+table StablehloBatchNormTrainingOptions {
+  epsilon:float;
+  feature_index:int;
 }
 
 // An operator takes tensors as inputs and outputs. The type of operation being

--- a/tensorflow/lite/core/api/flatbuffer_conversions.cc
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.cc
@@ -925,6 +925,10 @@ TfLiteStatus ParseOpDataTfLite(const Operator* op, BuiltinOperator op_type,
       return ParseStablehloComposite(op, error_reporter, allocator,
                                      builtin_data);
     }
+    case BuiltinOperator_STABLEHLO_BATCH_NORM_TRAINING: {
+      return ParseStablehloBatchNormTraining(op, error_reporter, allocator,
+                                             builtin_data);
+    }
     // TODO: skip param parsing for now since ops below don't have kernels
     case BuiltinOperator_STABLEHLO_SLICE:
     case BuiltinOperator_STABLEHLO_BROADCAST_IN_DIM:
@@ -2407,6 +2411,29 @@ TfLiteStatus ParseStablehloComposite(const Operator* op,
   TF_LITE_REPORT_ERROR(
       error_reporter,
       "Could not get 'stablehlo.composite' operation parameters.");
+  return kTfLiteError;
+}
+
+TfLiteStatus ParseStablehloBatchNormTraining(const Operator* op,
+                                             ErrorReporter* error_reporter,
+                                             BuiltinDataAllocator* allocator,
+                                             void** builtin_data) {
+  CheckParsePointerParams(op, error_reporter, allocator, builtin_data);
+
+  SafeBuiltinDataAllocator safe_allocator(allocator);
+  auto params =
+      safe_allocator.Allocate<TfLiteStablehloBatchNormTrainingParams>();
+  const StablehloBatchNormTrainingOptions* schema_params =
+      op->builtin_options_2_as_StablehloBatchNormTrainingOptions();
+  if (schema_params) {
+    params->epsilon = schema_params->epsilon();
+    params->feature_index = schema_params->feature_index();
+    *builtin_data = params.release();
+    return kTfLiteOk;
+  }
+  TF_LITE_REPORT_ERROR(
+      error_reporter,
+      "Could not get 'stablehlo.batch_norm_training' operation parameters.");
   return kTfLiteError;
 }
 

--- a/tensorflow/lite/core/api/flatbuffer_conversions.h
+++ b/tensorflow/lite/core/api/flatbuffer_conversions.h
@@ -449,6 +449,10 @@ TfLiteStatus ParseStablehloComposite(const Operator* op,
                                      ErrorReporter* error_reporter,
                                      BuiltinDataAllocator* allocator,
                                      void** builtin_data);
+TfLiteStatus ParseStablehloBatchNormTraining(const Operator* op,
+                                             ErrorReporter* error_reporter,
+                                             BuiltinDataAllocator* allocator,
+                                             void** builtin_data);
 
 }  // namespace tflite
 

--- a/tensorflow/lite/core/c/builtin_op_data.h
+++ b/tensorflow/lite/core/c/builtin_op_data.h
@@ -654,6 +654,13 @@ typedef struct {
   size_t attributes_size;
 } TfLiteStablehloCompositeParams;
 
+typedef struct {
+  // See the stablehlo spec for the explanation of the attributes:
+  // https://github.com/openxla/stablehlo/blob/main/docs/spec.md#batch_norm_training
+  float epsilon;
+  int64_t feature_index;
+} TfLiteStablehloBatchNormTrainingParams;
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tensorflow/lite/core/kernels/builtin_op_kernels.h
+++ b/tensorflow/lite/core/kernels/builtin_op_kernels.h
@@ -325,6 +325,8 @@ TfLiteRegistration* Register_REDUCE_WINDOW();
 TfLiteRegistration*
 Register_STABLEHLO_COMPOSITE();  // WARNING: not implemented, using this
                                  // op will crash the runtime
+
+TfLiteRegistration* Register_STABLEHLO_BATCH_NORM_TRAINING();
 }  // namespace builtin
 }  // namespace ops
 }  // namespace tflite

--- a/tensorflow/lite/core/kernels/register.cc
+++ b/tensorflow/lite/core/kernels/register.cc
@@ -385,6 +385,8 @@ BuiltinOpResolver::BuiltinOpResolver() {
   AddBuiltin(BuiltinOperator_STABLEHLO_PAD, Register_STABLEHLO_PAD());
   AddBuiltin(BuiltinOperator_STABLEHLO_COMPOSITE,
              Register_STABLEHLO_COMPOSITE());
+  AddBuiltin(BuiltinOperator_STABLEHLO_BATCH_NORM_TRAINING,
+             Register_STABLEHLO_BATCH_NORM_TRAINING());
   AddCustom("NumericVerify", tflite::ops::custom::Register_NUMERIC_VERIFY());
   // TODO(andrewharp, ahentz): Move these somewhere more appropriate so that
   // custom ops aren't always included by default.

--- a/tensorflow/lite/kernels/BUILD
+++ b/tensorflow/lite/kernels/BUILD
@@ -767,6 +767,7 @@ BUILTIN_KERNEL_SRCS = [
     "stablehlo_gather.cc",
     "stablehlo_add.cc",
     "stablehlo_composite.cc",
+    "stablehlo_batch_norm_training.cc",
     "stablehlo_multiply.cc",
     "stablehlo_pad.cc",
     "stablehlo_reduce_window.cc",
@@ -822,6 +823,7 @@ BUILTIN_KERNEL_DEPS = [
     ":control_flow_common",
     "@eigen_archive//:eigen3",
     "@flatbuffers",
+    "stablehlo_batch_norm_training",
     "//tensorflow/lite:framework_stable",
     "//tensorflow/lite:minimal_logging",
     "//tensorflow/lite:string_util",
@@ -3233,6 +3235,30 @@ cc_test(
         "//tensorflow/lite/core/c:common",
         "//tensorflow/lite/schema:schema_fbs",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "stablehlo_batch_norm_training",
+    hdrs = ["stablehlo_batch_norm_training.h"],
+    deps = [
+        ":kernel_util",
+        "//tensorflow/lite/c:c_api_types",
+        "//tensorflow/lite/core/c:common",
+    ],
+)
+
+cc_test(
+    name = "stablehlo_batch_norm_training_test",
+    size = "small",
+    srcs = ["stablehlo_batch_norm_training_test.cc"],
+    deps = [
+        ":test_main",
+        ":test_util",
+        "//tensorflow/lite/c:c_api_types",
+        "//tensorflow/lite/core/c:common",
+        "//tensorflow/lite/schema:schema_fbs",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/tensorflow/lite/kernels/stablehlo_batch_norm_training.cc
+++ b/tensorflow/lite/kernels/stablehlo_batch_norm_training.cc
@@ -1,0 +1,268 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,5fg
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/kernels/stablehlo_batch_norm_training.h"
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "Eigen/Core"
+#include "tensorflow/lite/kernels/internal/quantization_util.h"
+
+namespace tflite {
+namespace ops {
+namespace builtin {
+namespace stablehlo_batch_norm_training {
+namespace {
+
+constexpr int kInputTensor = 0;
+constexpr int kScaleTensor = 1;
+constexpr int kOffsetTensor = 2;
+constexpr int kOutputTensor = 0;
+constexpr int kBatchMeanTensor = 1;
+constexpr int kBatchVarTensor = 2;
+constexpr int kMaxReduceRank = 8;
+
+struct OpData {
+  int scratch_tensor_index;
+};
+
+TfLiteStatus GetOutputShape(TfLiteContext* context, TfLiteIntArray* input_dims,
+                            const int input_num_dims, std::vector<int64_t> axis,
+                            int64_t num_axis, TfLiteIntArray** output_shape) {
+  if (input_num_dims == 0) {
+    *output_shape = TfLiteIntArrayCreate(0);
+    return kTfLiteOk;
+  }
+  // Calculates size of reducing axis.
+  int64_t num_reduce_axis = num_axis;
+  for (int64_t i = 0; i < num_axis; ++i) {
+    int current = axis[i];
+    if (current < 0) {
+      current += input_num_dims;
+    }
+    TF_LITE_ENSURE(context, current >= 0 && current < input_num_dims);
+    for (int64_t j = 0; j < i; ++j) {
+      int previous = axis[j];
+      if (previous < 0) {
+        previous += input_num_dims;
+      }
+      if (current == previous) {
+        --num_reduce_axis;
+        break;
+      }
+    }
+    // Determines output dimensions.
+    TfLiteIntArray* output_dims =
+        TfLiteIntArrayCreate(input_num_dims - num_reduce_axis);
+    int num_skip_axis = 0;
+    for (int idx = 0; idx < input_num_dims; ++idx) {
+      bool is_axis = false;
+      for (int64_t axis_idx = 0; axis_idx < num_axis; ++axis_idx) {
+        if (axis[axis_idx] == idx || axis[axis_idx] + input_num_dims == idx) {
+          ++num_skip_axis;
+          is_axis = true;
+          break;
+        }
+      }
+      if (!is_axis) {
+        output_dims->data[idx - num_skip_axis] = input_dims->data[idx];
+      }
+    }
+    *output_shape = output_dims;
+    return kTfLiteOk;
+  }
+}
+
+template <typename DataType>
+TfLiteStatus BatchNormInference(
+    TfLiteContext* context, TfLiteNode* node, const TfLiteTensor* operand,
+    const TfLiteTensor* scale, const TfLiteTensor* offset,
+    const TfLiteTensor* mean, const TfLiteTensor* variance, const float epsilon,
+    const int64_t feature_index, TfLiteTensor* output) {
+  const int operand_rank = operand->dims->size;
+
+  const DataType* scale_data = GetTensorData<DataType>(scale);
+  const DataType* offset_data = GetTensorData<DataType>(offset);
+  const DataType* mean_data = GetTensorData<DataType>(mean);
+  const DataType* variance_data = GetTensorData<DataType>(variance);
+  const DataType* operand_data = GetTensorData<DataType>(operand);
+  DataType* output_data = GetTensorData<DataType>(output);
+  for (int64_t i = 0; i < NumElements(operand); ++i) {
+    int64_t feature_index_value = i % operand->dims->data[feature_index];
+    DataType centered_value = operand_data[i] - mean_data[feature_index_value];
+    DataType stddev = static_cast<DataType>(std::sqrt(
+        static_cast<float>(variance_data[feature_index_value]) + epsilon));
+    output_data[i] =
+        scale_data[feature_index_value] * (centered_value / stddev) +
+        offset_data[feature_index_value];
+  }
+  return kTfLiteOk;
+}
+
+template <typename DataType>
+TfLiteStatus EvalImpl(TfLiteContext* context, TfLiteNode* node,
+                      const TfLiteTensor* operand, const TfLiteTensor* scale,
+                      const TfLiteTensor* offset, TfLiteTensor* output,
+                      TfLiteTensor* batch_mean, TfLiteTensor* batch_var,
+                      const int64_t feature_index, const float epsilon) {
+  TF_LITE_ENSURE_OK(
+      context,
+      tflite::stablehlo_batch_norm_training::reference::ComputeVariance<
+          DataType>(context, node, operand, feature_index, batch_mean,
+                    batch_var, output));
+
+  TF_LITE_ENSURE_OK(
+      context, BatchNormInference<DataType>(context, node, operand, scale,
+                                            offset, batch_mean, batch_var,
+                                            epsilon, feature_index, output));
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Prepare(TfLiteContext* context, TfLiteNode* node) {
+  TF_LITE_ENSURE_EQ(context, NumInputs(node), 3);
+  TF_LITE_ENSURE_EQ(context, NumOutputs(node), 3);
+
+  const TfLiteTensor* input;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kInputTensor, &input));
+  const TfLiteTensor* scale;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kScaleTensor, &scale));
+  const TfLiteTensor* offset;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kOffsetTensor, &offset));
+
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+  TfLiteTensor* batch_mean;
+  TF_LITE_ENSURE_OK(
+      context, GetOutputSafe(context, node, kBatchMeanTensor, &batch_mean));
+  TfLiteTensor* batch_var;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kBatchVarTensor, &batch_var));
+
+  const TfLiteStablehloBatchNormTrainingParams* data =
+      reinterpret_cast<TfLiteStablehloBatchNormTrainingParams*>(
+          node->builtin_data);
+  const int64_t feature_index = data->feature_index;
+
+  const int input_rank = input->dims->size;
+  std::vector<int64_t> axis;
+  for (int64_t i = 0; i < input_rank; ++i) {
+    if (i != feature_index) {
+      axis.push_back(i);
+    }
+  }
+
+  TfLiteIntArray* batch_mean_var_shape = nullptr;
+  TF_LITE_ENSURE_OK(
+      context, GetOutputShape(context, input->dims, input->dims->size, axis,
+                              input_rank - 1, &batch_mean_var_shape));
+  context->ResizeTensor(context, batch_mean, batch_mean_var_shape);
+  TF_LITE_ENSURE_OK(
+      context, GetOutputShape(context, input->dims, input->dims->size, axis,
+                              input_rank - 1, &batch_mean_var_shape));
+  context->ResizeTensor(context, batch_var, batch_mean_var_shape);
+
+  TF_LITE_ENSURE(context,
+                 feature_index >= 0 && feature_index < input->dims->size);
+  TF_LITE_ENSURE_TYPES_EQ(context, output->type, input->type);
+  TF_LITE_ENSURE_EQ(context, scale->dims->size, 1);
+  TF_LITE_ENSURE_EQ(context, scale->dims->data[0],
+                    input->dims->data[feature_index]);
+  TF_LITE_ENSURE_EQ(context, offset->dims->size, 1);
+  TF_LITE_ENSURE_EQ(context, offset->dims->data[0],
+                    input->dims->data[feature_index]);
+  TF_LITE_ENSURE_EQ(context, batch_mean->dims->size, 1);
+  TF_LITE_ENSURE_EQ(context, batch_mean->dims->data[0],
+                    input->dims->data[feature_index]);
+  TF_LITE_ENSURE_EQ(context, batch_var->dims->size, 1);
+  TF_LITE_ENSURE_EQ(context, batch_var->dims->data[0],
+                    input->dims->data[feature_index]);
+
+  TF_LITE_ENSURE_OK(
+      context,
+      context->ResizeTensor(context, output, TfLiteIntArrayCopy(input->dims)));
+
+  return kTfLiteOk;
+}
+
+TfLiteStatus Eval(TfLiteContext* context, TfLiteNode* node) {
+  const TfLiteTensor* operand;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kInputTensor, &operand));
+  const TfLiteTensor* scale;
+  TF_LITE_ENSURE_OK(context, GetInputSafe(context, node, kScaleTensor, &scale));
+  const TfLiteTensor* offset;
+  TF_LITE_ENSURE_OK(context,
+                    GetInputSafe(context, node, kOffsetTensor, &offset));
+  TfLiteTensor* output;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kOutputTensor, &output));
+  TfLiteTensor* batch_mean;
+  TF_LITE_ENSURE_OK(
+      context, GetOutputSafe(context, node, kBatchMeanTensor, &batch_mean));
+  TfLiteTensor* batch_var;
+  TF_LITE_ENSURE_OK(context,
+                    GetOutputSafe(context, node, kBatchVarTensor, &batch_var));
+
+  const TfLiteStablehloBatchNormTrainingParams* data =
+      reinterpret_cast<TfLiteStablehloBatchNormTrainingParams*>(
+          node->builtin_data);
+  const int64_t feature_index = data->feature_index;
+  const float epsilon = data->epsilon;
+
+  if (operand->type == kTfLiteFloat32) {
+    return EvalImpl<float>(context, node, operand, scale, offset, output,
+                           batch_mean, batch_var, feature_index, epsilon);
+  } else if (operand->type == kTfLiteFloat16) {
+    return EvalImpl<Eigen::half>(context, node, operand, scale, offset, output,
+                                 batch_mean, batch_var, feature_index, epsilon);
+  } else if (operand->type == kTfLiteBFloat16) {
+    return EvalImpl<Eigen::bfloat16>(context, node, operand, scale, offset,
+                                     output, batch_mean, batch_var,
+                                     feature_index, epsilon);
+  } else {
+    TF_LITE_KERNEL_LOG(context, "Type %s not currently supported.",
+                       TfLiteTypeGetName(operand->type));
+    return kTfLiteError;
+  }
+}
+
+void* Init(TfLiteContext* context, const char* buffer, size_t length) {
+  auto* data = new OpData;
+  return data;
+}
+
+void Free(TfLiteContext* context, void* node_data) {
+  delete static_cast<OpData*>(node_data);
+}
+
+}  // namespace
+}  // namespace stablehlo_batch_norm_training
+
+TfLiteRegistration* Register_STABLEHLO_BATCH_NORM_TRAINING() {
+  static TfLiteRegistration r = {stablehlo_batch_norm_training::Init,
+                                 stablehlo_batch_norm_training::Free,
+                                 stablehlo_batch_norm_training::Prepare,
+                                 stablehlo_batch_norm_training::Eval};
+  return &r;
+}
+
+}  // namespace builtin
+}  // namespace ops
+}  // namespace tflite

--- a/tensorflow/lite/kernels/stablehlo_batch_norm_training.h
+++ b/tensorflow/lite/kernels/stablehlo_batch_norm_training.h
@@ -1,0 +1,102 @@
+/* Copyright 2023 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TENSORFLOW_LITE_KERNELS_STABLEHLO_BATCH_NORM_TRAINING_H_
+#define TENSORFLOW_LITE_KERNELS_STABLEHLO_BATCH_NORM_TRAINING_H_
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "tensorflow/lite/kernels/internal/reference/reduce.h"
+#include "tensorflow/lite/kernels/internal/runtime_shape.h"
+#include "tensorflow/lite/kernels/internal/tensor_ctypes.h"
+#include "tensorflow/lite/kernels/internal/types.h"
+#include "tensorflow/lite/kernels/kernel_util.h"
+
+namespace tflite {
+namespace stablehlo_batch_norm_training {
+namespace reference {
+
+constexpr int kMaxReduceRank = 8;
+
+template <typename DataType>
+TfLiteStatus ComputeMean(TfLiteContext* context, TfLiteNode* node,
+                         const TfLiteTensor* operand, int64_t feature_index,
+                         TfLiteTensor* batch_mean) {
+  const int operand_rank = operand->dims->size;
+  std::vector<int> dimarray;
+  for (int i = 0; i < operand_rank; ++i) {
+    if (i != feature_index) {
+      dimarray.push_back(i);
+    }
+  }
+  int resolved_axis[kMaxReduceRank];
+  int temp_index[kMaxReduceRank];
+  int temp_sum[NumElements(batch_mean)];
+  TF_LITE_ENSURE(context,
+                 reference_ops::ReduceGeneric<DataType>(
+                     GetTensorData<DataType>(operand), operand->dims->data,
+                     operand->dims->size, GetTensorData<DataType>(batch_mean),
+                     batch_mean->dims->data, batch_mean->dims->size,
+                     dimarray.data(), dimarray.size(), false, temp_index,
+                     resolved_axis, static_cast<DataType>(0),
+                     [](const DataType current, const DataType in) -> DataType {
+                       return in + current;
+                     }));
+  int64_t operand_size = 1;
+  for (int i = 0; i < operand->dims->size; ++i) {
+    operand_size *= operand->dims->data[i];
+  }
+  int64_t feature_dim = operand->dims->data[feature_index];
+  int64_t divisor = operand_size / feature_dim;
+
+  DataType* mean_data = GetTensorData<DataType>(batch_mean);
+  for (int64_t i = 0; i < NumElements(batch_mean); ++i) {
+    mean_data[i] = mean_data[i] / divisor;
+  }
+  // }
+  return kTfLiteOk;
+}
+
+template <typename DataType>
+TfLiteStatus ComputeVariance(TfLiteContext* context, TfLiteNode* node,
+                             const TfLiteTensor* operand, int64_t feature_index,
+                             TfLiteTensor* batch_mean, TfLiteTensor* batch_var,
+                             TfLiteTensor* centered_operand) {
+  TF_LITE_ENSURE_STATUS(
+      ComputeMean<DataType>(context, node, operand, feature_index, batch_mean));
+
+  DataType* mean_data = GetTensorData<DataType>(batch_mean);
+  const int operand_rank = operand->dims->size;
+  std::vector<int> broadcast_shape(operand_rank, 1);
+  broadcast_shape[feature_index] = operand->dims->data[feature_index];
+
+  const DataType* operand_data = GetTensorData<DataType>(operand);
+  DataType* centered_operand_data = GetTensorData<DataType>(centered_operand);
+  for (int64_t i = 0; i < NumElements(operand); ++i) {
+    centered_operand_data[i] =
+        operand_data[i] - mean_data[i % broadcast_shape[feature_index]];
+    centered_operand_data[i] *= centered_operand_data[i];
+  }
+  return ComputeMean<DataType>(context, node, centered_operand, feature_index,
+                               batch_var);
+}
+
+}  // namespace reference
+}  // namespace stablehlo_batch_norm_training
+}  // namespace tflite
+
+#endif  // TENSORFLOW_LITE_KERNELS_STABLEHLO_BATCH_NORM_TRAINING_H_

--- a/tensorflow/lite/kernels/stablehlo_batch_norm_training.h
+++ b/tensorflow/lite/kernels/stablehlo_batch_norm_training.h
@@ -32,6 +32,191 @@ namespace reference {
 
 constexpr int kMaxReduceRank = 8;
 
+int compute_quantized_add(int input_value1, int input_value2, int left_shift,
+                          double scale, int zero_point) {
+  const double twice_max_input_scale = 2 * scale;
+  const double real_input_multiplier = scale / twice_max_input_scale;
+  const double real_output_multiplier =
+      twice_max_input_scale / ((1 << left_shift) * scale);
+  int32_t output_multiplier;
+  int output_shift;
+  int32_t input_multiplier;
+  int input_shift;
+
+  tflite::QuantizeMultiplierSmallerThanOneExp(real_input_multiplier,
+                                              &input_multiplier, &input_shift);
+  if (real_output_multiplier > 1) {
+    tflite::QuantizeMultiplierGreaterThanOne(real_output_multiplier,
+                                             &output_multiplier, &output_shift);
+  } else {
+    tflite::QuantizeMultiplierSmallerThanOneExp(
+        real_output_multiplier, &output_multiplier, &output_shift);
+  }
+  input_value1 = input_value1 - zero_point;
+  input_value2 = input_value2 - zero_point;
+  const int shifted_input_value1 = input_value1 * (1 << left_shift);
+  const int shifted_input_value2 = input_value2 * (1 << left_shift);
+  const int scaled_input_value1 =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input_value1, input_multiplier, input_shift);
+  const int scaled_input_value2 =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input_value2, input_multiplier, input_shift);
+  const int raw_addition_value = scaled_input_value1 + scaled_input_value2;
+  return MultiplyByQuantizedMultiplierSmallerThanOneExp(
+             raw_addition_value, output_multiplier, output_shift) +
+         zero_point;
+}
+
+int compute_quantized_sub(int input_value1, int input_value2, int left_shift,
+                          double scale, int zero_point) {
+  const double twice_max_input_scale = 2 * scale;
+  const double real_input_multiplier = scale / twice_max_input_scale;
+  const double real_output_multiplier =
+      twice_max_input_scale / ((1 << left_shift) * scale);
+  int32_t output_multiplier;
+  int output_shift;
+  int32_t input_multiplier;
+  int input_shift;
+
+  tflite::QuantizeMultiplierSmallerThanOneExp(real_input_multiplier,
+                                              &input_multiplier, &input_shift);
+  if (real_output_multiplier > 1) {
+    tflite::QuantizeMultiplierGreaterThanOne(real_output_multiplier,
+                                             &output_multiplier, &output_shift);
+  } else {
+    tflite::QuantizeMultiplierSmallerThanOneExp(
+        real_output_multiplier, &output_multiplier, &output_shift);
+  }
+  input_value1 = input_value1 - zero_point;
+  input_value2 = input_value2 - zero_point;
+  const int shifted_input_value1 = input_value1 * (1 << left_shift);
+  const int shifted_input_value2 = input_value2 * (1 << left_shift);
+  const int scaled_input_value1 =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input_value1, input_multiplier, input_shift);
+  const int scaled_input_value2 =
+      MultiplyByQuantizedMultiplierSmallerThanOneExp(
+          shifted_input_value2, input_multiplier, input_shift);
+  const int raw_subration_value = scaled_input_value1 - scaled_input_value2;
+  return MultiplyByQuantizedMultiplierSmallerThanOneExp(
+             raw_subration_value, output_multiplier, output_shift) +
+         zero_point;
+}
+
+template <typename DataType>
+int compute_quantized_div(int input_value1, int input_value2, double scale,
+                          int zero_point) {
+  int32_t div_multiplier;
+  int div_shift;
+  const double real_div_multiplier = scale / (scale * scale);
+  QuantizeMultiplier(real_div_multiplier, &div_multiplier, &div_shift);
+  if (input_value2 < 0) {
+    // Invert signs to avoid a negative input_value2 as input2_inv needs to be
+    // positive to be used as multiplier of MultiplyByQuantizedMultiplier.
+    input_value1 = -input_value1;
+    input_value2 = -input_value2;
+  }
+  int recip_shift;
+
+  const int32_t input2_inv = GetReciprocal(input_value2, 31, &recip_shift);
+  const int headroom = CountLeadingSignBits(input_value1);
+  const int32_t unscaled_quotient = MultiplyByQuantizedMultiplierGreaterThanOne(
+      input_value1, input2_inv, headroom);
+  const int total_shift = div_shift - recip_shift - headroom;
+  int32_t unclamped_result;
+  if (std::abs(total_shift) > 31) {
+    unclamped_result =
+        zero_point + MultiplyByQuantizedMultiplierGreaterThanOne(
+                         unscaled_quotient, div_multiplier, total_shift);
+  } else {
+    unclamped_result =
+        zero_point + MultiplyByQuantizedMultiplierSmallerThanOneExp(
+                         unscaled_quotient, div_multiplier, total_shift);
+  }
+  return std::min(
+      static_cast<int>(std::numeric_limits<DataType>::max()),
+      std::max(static_cast<int>(std::numeric_limits<DataType>::min()),
+               unclamped_result));
+}
+
+template <typename DataType>
+int compute_quantized_mul(int input_value1, int input_value2,
+                          const double scale, int zero_point) {
+  int32_t mul_multiplier;
+  int mul_shift;
+  QuantizeMultiplier(scale, &mul_multiplier, &mul_shift);
+  const int32_t input1_val = zero_point + input_value1;
+  const int32_t input2_val = zero_point + input_value2;
+  const int32_t unclamped_result =
+      zero_point + MultiplyByQuantizedMultiplier(input1_val * input2_val,
+                                                 mul_multiplier, mul_shift);
+  return std::min(
+      static_cast<int>(std::numeric_limits<DataType>::max()),
+      std::max(static_cast<int>(std::numeric_limits<DataType>::min()),
+               unclamped_result));
+}
+
+inline void SetRsqrtOutputMultiplier(const float input_scale,
+                                     const float output_scale,
+                                     int32_t* multiplier, int32_t* shift) {
+  const double scale = 1. / (std::sqrt(input_scale) * output_scale);
+  QuantizeMultiplier(scale, multiplier, shift);
+}
+
+template <typename DataType>
+int compute_quantized_rsqrt(int input_value, const int32_t kShift,
+                            const double scale, int zero_point) {
+  int multiplier, shift;
+  SetRsqrtOutputMultiplier(scale, scale, &multiplier, &shift);
+  const int kMin = std::numeric_limits<DataType>::min();
+  const int kMax = std::numeric_limits<DataType>::max();
+  const int32_t value = (input_value - zero_point);
+  if (value == 0) {
+    // Assume that any value close to 0 represents the max output value.
+    return static_cast<DataType>(kMax);
+  }
+  int32_t inv_sqrt_multiplier;
+  int inv_sqrt_shift;
+  GetInvSqrtQuantizedMultiplierExp(value, kReverseShift, &inv_sqrt_multiplier,
+                                   &inv_sqrt_shift);
+  const int32_t data = MultiplyByQuantizedMultiplier(1, inv_sqrt_multiplier,
+                                                     inv_sqrt_shift + kShift);
+  const int32_t output =
+      MultiplyByQuantizedMultiplier(data, multiplier, shift - kShift) +
+      zero_point;
+  return static_cast<DataType>(std::min(std::max(output, kMin), kMax));
+}
+
+template <typename DataType>
+TfLiteStatus ComputeQuantizedMean(TfLiteContext* context, TfLiteNode* node,
+                                  const TfLiteTensor* operand,
+                                  int64_t feature_index,
+                                  TfLiteTensor* batch_mean) {
+  const int operand_rank = operand->dims->size;
+  std::vector<int> dimarray;
+  for (int i = 0; i < operand_rank; ++i) {
+    if (i != feature_index) {
+      dimarray.push_back(i);
+    }
+  }
+  int resolved_axis[kMaxReduceRank] = {0};
+  int temp_index[kMaxReduceRank] = {0};
+  std::vector<int> temp_sum(dimarray.size(), 0);
+  int32_t multiplier;
+  int shift;
+  QuantizeMultiplier(1.0, &multiplier, &shift);
+  TF_LITE_ENSURE(
+      context, reference_ops::QuantizedMeanOrSum(
+                   GetTensorData<DataType>(operand), operand->params.zero_point,
+                   operand->dims->data, operand->dims->size,
+                   GetTensorData<DataType>(batch_mean), multiplier, shift,
+                   operand->params.zero_point, batch_mean->dims->data,
+                   batch_mean->dims->size, dimarray.data(), dimarray.size(),
+                   false, temp_index, resolved_axis, temp_sum.data(), false));
+  return kTfLiteOk;
+}
+
 template <typename DataType>
 TfLiteStatus ComputeMean(TfLiteContext* context, TfLiteNode* node,
                          const TfLiteTensor* operand, int64_t feature_index,
@@ -69,6 +254,36 @@ TfLiteStatus ComputeMean(TfLiteContext* context, TfLiteNode* node,
   }
   // }
   return kTfLiteOk;
+}
+
+template <typename DataType>
+TfLiteStatus ComputeQuantizedVariance(TfLiteContext* context, TfLiteNode* node,
+                                      const TfLiteTensor* operand,
+                                      int64_t feature_index,
+                                      TfLiteTensor* batch_mean,
+                                      TfLiteTensor* batch_var,
+                                      TfLiteTensor* centered_operand) {
+  TF_LITE_ENSURE_STATUS(ComputeQuantizedMean<DataType>(
+      context, node, operand, feature_index, batch_mean));
+
+  DataType* mean_data = GetTensorData<DataType>(batch_mean);
+  const int operand_rank = operand->dims->size;
+  std::vector<int> broadcast_shape(operand_rank, 1);
+  broadcast_shape[feature_index] = operand->dims->data[feature_index];
+
+  const DataType* operand_data = GetTensorData<DataType>(operand);
+  DataType* centered_operand_data = GetTensorData<DataType>(centered_operand);
+  const int left_shift = (operand->type == kTfLiteInt16) ? 15 : 20;
+  for (int64_t i = 0; i < NumElements(operand); ++i) {
+    const int raw_centered_output = compute_quantized_sub(
+        operand_data[i], mean_data[i % NumElements(batch_mean)], left_shift,
+        operand->params.scale, operand->params.zero_point);
+    centered_operand_data[i] = compute_quantized_mul<DataType>(
+        raw_centered_output, raw_centered_output, operand->params.scale,
+        operand->params.zero_point);
+  }
+  return ComputeQuantizedMean<DataType>(context, node, centered_operand,
+                                        feature_index, batch_var);
 }
 
 template <typename DataType>

--- a/tensorflow/lite/kernels/stablehlo_batch_norm_training_test.cc
+++ b/tensorflow/lite/kernels/stablehlo_batch_norm_training_test.cc
@@ -1,0 +1,261 @@
+/* Copyright 2024 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <vector>
+
+#include "Eigen/Core"
+#include "tensorflow/lite/c/c_api_types.h"
+#include "tensorflow/lite/c/common.h"
+#include "tensorflow/lite/core/c/builtin_op_data.h"
+#include "tensorflow/lite/kernels/test_util.h"
+#include "tensorflow/lite/schema/schema_generated.h"
+
+namespace tflite {
+namespace {
+
+template <typename T>
+tflite::TensorType GetTTEnum();
+
+template <>
+tflite::TensorType GetTTEnum<Eigen::half>() {
+  return tflite::TensorType_FLOAT16;
+}
+
+template <>
+tflite::TensorType GetTTEnum<Eigen::bfloat16>() {
+  return tflite::TensorType_BFLOAT16;
+}
+
+template <>
+tflite::TensorType GetTTEnum<float>() {
+  return tflite::TensorType_FLOAT32;
+}
+
+using ::testing::ElementsAreArray;
+
+class StablehloBatchNormTrainingOpModel : public SingleOpModel {
+ public:
+  StablehloBatchNormTrainingOpModel(
+      const TensorData& input, const TensorData& scale,
+      const TensorData& offset, const TensorData& output,
+      const TensorData& batch_mean, const TensorData& batch_var,
+      const TfLiteStablehloBatchNormTrainingParams& params) {
+    input_ = AddInput(input);
+    scale_ = AddInput(scale);
+    offset_ = AddInput(offset);
+    output_ = AddOutput(output);
+    batch_mean_ = AddOutput(batch_mean);
+    batch_var_ = AddOutput(batch_var);
+    SetBuiltinOp(BuiltinOperator_STABLEHLO_BATCH_NORM_TRAINING,
+                 BuiltinOptions2_StablehloBatchNormTrainingOptions,
+                 CreateStablehloBatchNormTrainingOptions(
+                     builder_, params.epsilon, params.feature_index)
+                     .Union());
+    BuildInterpreter({GetShape(input_), GetShape(scale_), GetShape(offset_)},
+                     /*num_threads=*/-1, /*allow_fp32_relax_to_fp16=*/false,
+                     /*apply_delegate=*/false, /*allocate_and_delegate=*/false,
+                     /*use_simple_allocator=*/false);
+
+    AllocateAndDelegate(true);
+  }
+
+  template <typename T>
+  void SetInput(std::initializer_list<T> data) {
+    PopulateTensor<T>(input_, data);
+  }
+
+  template <typename T>
+  void SetQInput(std::initializer_list<T> data) {
+    QuantizeAndPopulate<T>(input_, data);
+  }
+
+  template <typename T>
+  void SetScale(std::initializer_list<T> data) {
+    PopulateTensor<T>(scale_, data);
+  }
+
+  template <typename T>
+  void SetQScale(std::initializer_list<T> data) {
+    QuantizeAndPopulate<T>(scale_, data);
+  }
+
+  template <typename T>
+  void SetOffset(std::initializer_list<T> data) {
+    PopulateTensor<T>(offset_, data);
+  }
+
+  template <typename T>
+  void SetQOffset(std::initializer_list<T> data) {
+    QuantizeAndPopulate<T>(offset_, data);
+  }
+
+  template <typename T>
+  std::vector<T> GetOutput() {
+    return ExtractVector<T>(output_);
+  }
+
+  template <typename T>
+  std::vector<T> GetBatchMean() {
+    return ExtractVector<T>(batch_mean_);
+  }
+
+  template <typename T>
+  std::vector<T> GetBatchVar() {
+    return ExtractVector<T>(batch_var_);
+  }
+
+  int input() { return input_; }
+  int scale() { return scale_; }
+  int offset() { return offset_; }
+
+ protected:
+  int input_;
+  int scale_;
+  int offset_;
+  int output_;
+  int batch_mean_;
+  int batch_var_;
+};
+
+template <typename Float>
+class StablehloBatchNormTrainingTestFloat : public ::testing::Test {
+ public:
+  using FloatType = Float;
+};
+
+using FloatTestTypes = ::testing::Types<float, Eigen::half, Eigen::bfloat16>;
+
+TYPED_TEST_SUITE(StablehloBatchNormTrainingTestFloat, FloatTestTypes);
+
+TYPED_TEST(StablehloBatchNormTrainingTestFloat,
+           StablehloBatchNormTrainingFloatTest) {
+  using Float = typename TestFixture::FloatType;
+  TfLiteStablehloBatchNormTrainingParams params = {0.0 /*epsilon*/,
+                                                   2 /*feature_index*/};
+  StablehloBatchNormTrainingOpModel model(
+      {GetTTEnum<Float>(), {2, 2, 2}}, {GetTTEnum<Float>(), {2}},
+      {GetTTEnum<Float>(), {2}}, {GetTTEnum<Float>(), {}},
+      {GetTTEnum<Float>(), {}}, {GetTTEnum<Float>(), {}}, params);
+  model.SetInput<Float>({static_cast<Float>(1.0), static_cast<Float>(2.0),
+                         static_cast<Float>(3.0), static_cast<Float>(4.0),
+                         static_cast<Float>(3.0), static_cast<Float>(4.0),
+                         static_cast<Float>(1.0), static_cast<Float>(2.0)});
+  model.SetScale<Float>({static_cast<Float>(1.0), static_cast<Float>(1.0)});
+  model.SetOffset<Float>({static_cast<Float>(1.0), static_cast<Float>(1.0)});
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+
+  EXPECT_THAT(model.GetOutput<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(0.0), static_cast<Float>(0.0),
+                   static_cast<Float>(2.0), static_cast<Float>(2.0),
+                   static_cast<Float>(2.0), static_cast<Float>(2.0),
+                   static_cast<Float>(0.0), static_cast<Float>(0.0)},
+                  0.1)));
+  EXPECT_THAT(model.GetBatchMean<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(2.0), static_cast<Float>(3.0)}, 0.1)));
+  EXPECT_THAT(model.GetBatchVar<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(1.0), static_cast<Float>(1.0)}, 0.1)));
+}
+
+TYPED_TEST(StablehloBatchNormTrainingTestFloat, Ex2) {
+  using Float = typename TestFixture::FloatType;
+  TfLiteStablehloBatchNormTrainingParams params = {0.0 /*epsilon*/,
+                                                   1 /*feature_index*/};
+  StablehloBatchNormTrainingOpModel model(
+      {GetTTEnum<Float>(), {2, 3}}, {GetTTEnum<Float>(), {3}},
+      {GetTTEnum<Float>(), {3}}, {GetTTEnum<Float>(), {}},
+      {GetTTEnum<Float>(), {}}, {GetTTEnum<Float>(), {}}, params);
+  model.SetInput<Float>({static_cast<Float>(1.0), static_cast<Float>(2.0),
+                         static_cast<Float>(3.0), static_cast<Float>(4.0),
+                         static_cast<Float>(5.0), static_cast<Float>(6.0)});
+  model.SetScale<Float>({static_cast<Float>(1.0), static_cast<Float>(1.0),
+                         static_cast<Float>(1.0)});
+  model.SetOffset<Float>({static_cast<Float>(0.0), static_cast<Float>(0.0),
+                          static_cast<Float>(0.0)});
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetOutput<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(-1.0), static_cast<Float>(-1.0),
+                   static_cast<Float>(-1.0), static_cast<Float>(1.0),
+                   static_cast<Float>(1.0), static_cast<Float>(1.0)},
+                  0.1)));
+  EXPECT_THAT(model.GetBatchMean<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(2.5), static_cast<Float>(3.5),
+                   static_cast<Float>(4.5)},
+                  0.1)));
+  EXPECT_THAT(model.GetBatchVar<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(2.25), static_cast<Float>(2.25),
+                   static_cast<Float>(2.25)},
+                  0.1)));
+}
+
+TYPED_TEST(StablehloBatchNormTrainingTestFloat,
+           StablehloBatchNormTrainingFloatTestWithNonzeroEpsilon) {
+  using Float = typename TestFixture::FloatType;
+  TfLiteStablehloBatchNormTrainingParams params = {1.0 /*epsilon*/,
+                                                   1 /*feature_index*/};
+  StablehloBatchNormTrainingOpModel model(
+      {GetTTEnum<Float>(), {2, 2, 2}}, {GetTTEnum<Float>(), {2}},
+      {GetTTEnum<Float>(), {2}}, {GetTTEnum<Float>(), {}},
+      {GetTTEnum<Float>(), {}}, {GetTTEnum<Float>(), {}}, params);
+  model.SetInput<Float>(
+      {static_cast<Float>(4.721), static_cast<Float>(-1.903),
+       static_cast<Float>(1.939), static_cast<Float>(-3.508),
+       static_cast<Float>(-5.371), static_cast<Float>(-0.0968),
+       static_cast<Float>(10.517), static_cast<Float>(-9.530)});
+  model.SetScale<Float>({static_cast<Float>(2.0), static_cast<Float>(3.0)});
+  model.SetOffset<Float>({static_cast<Float>(2.0), static_cast<Float>(2.0)});
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  const std::vector<Float> expected_values = {
+      static_cast<Float>(4.821),  static_cast<Float>(1.312),
+      static_cast<Float>(3.363),  static_cast<Float>(0.684),
+      static_cast<Float>(-0.467), static_cast<Float>(2.019),
+      static_cast<Float>(7.859),  static_cast<Float>(-1.672)};
+  const std::vector<Float> expected_mean = {static_cast<Float>(-0.662),
+                                            static_cast<Float>(-0.145)};
+  const std::vector<Float> expected_var = {static_cast<Float>(13.560),
+                                           static_cast<Float>(57.780)};
+  EXPECT_THAT(model.GetOutput<Float>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<Float>(4.821), static_cast<Float>(1.312),
+                   static_cast<Float>(3.363), static_cast<Float>(0.684),
+                   static_cast<Float>(-0.467), static_cast<Float>(2.019),
+                   static_cast<Float>(7.859), static_cast<Float>(-1.672)},
+                  0.1)));
+  EXPECT_THAT(
+      model.GetBatchMean<Float>(),
+      ElementsAreArray(ArrayFloatNear(
+          {static_cast<Float>(-0.662), static_cast<Float>(-0.145)}, 0.1)));
+  EXPECT_THAT(
+      model.GetBatchVar<Float>(),
+      ElementsAreArray(ArrayFloatNear(
+          {static_cast<Float>(13.560), static_cast<Float>(57.780)}, 0.1)));
+}
+
+}  // namespace
+}  // namespace tflite

--- a/tensorflow/lite/kernels/stablehlo_batch_norm_training_test.cc
+++ b/tensorflow/lite/kernels/stablehlo_batch_norm_training_test.cc
@@ -49,6 +49,16 @@ tflite::TensorType GetTTEnum<float>() {
   return tflite::TensorType_FLOAT32;
 }
 
+template <>
+tflite::TensorType GetTTEnum<int8_t>() {
+  return tflite::TensorType_INT8;
+}
+
+template <>
+tflite::TensorType GetTTEnum<int16_t>() {
+  return tflite::TensorType_INT16;
+}
+
 using ::testing::ElementsAreArray;
 
 class StablehloBatchNormTrainingOpModel : public SingleOpModel {
@@ -58,12 +68,12 @@ class StablehloBatchNormTrainingOpModel : public SingleOpModel {
       const TensorData& offset, const TensorData& output,
       const TensorData& batch_mean, const TensorData& batch_var,
       const TfLiteStablehloBatchNormTrainingParams& params) {
-    input_ = AddInput(input);
-    scale_ = AddInput(scale);
-    offset_ = AddInput(offset);
-    output_ = AddOutput(output);
-    batch_mean_ = AddOutput(batch_mean);
-    batch_var_ = AddOutput(batch_var);
+    input_ = AddInput(SymmetricInt16Scaling(input));
+    scale_ = AddInput(SymmetricInt16Scaling(scale));
+    offset_ = AddInput(SymmetricInt16Scaling(offset));
+    output_ = AddOutput(SymmetricInt16Scaling(output));
+    batch_mean_ = AddOutput(SymmetricInt16Scaling(batch_mean));
+    batch_var_ = AddOutput(SymmetricInt16Scaling(batch_var));
     SetBuiltinOp(BuiltinOperator_STABLEHLO_BATCH_NORM_TRAINING,
                  BuiltinOptions2_StablehloBatchNormTrainingOptions,
                  CreateStablehloBatchNormTrainingOptions(
@@ -122,9 +132,46 @@ class StablehloBatchNormTrainingOpModel : public SingleOpModel {
     return ExtractVector<T>(batch_var_);
   }
 
+  template <typename QuantizedType>
+  std::vector<float> GetDequantizedOutput() {
+    return Dequantize<QuantizedType>(
+        this->template ExtractVector<QuantizedType>(this->output_),
+        GetScale(this->output_), GetZeroPoint(this->output_));
+  }
+
+  template <typename QuantizedType>
+  std::vector<float> GetDequantizedBatchMean() {
+    return Dequantize<QuantizedType>(
+        this->template ExtractVector<QuantizedType>(this->batch_mean_),
+        GetScale(this->batch_mean_), GetZeroPoint(this->batch_mean_));
+  }
+
+  template <typename QuantizedType>
+  std::vector<float> GetDequantizedBatchVar() {
+    return Dequantize<QuantizedType>(
+        this->template ExtractVector<QuantizedType>(this->batch_var_),
+        GetScale(this->batch_var_), GetZeroPoint(this->batch_var_));
+  }
+
   int input() { return input_; }
   int scale() { return scale_; }
   int offset() { return offset_; }
+
+  TensorData SymmetricInt16Scaling(TensorData tensor) {
+    // Symmetric range and null zero-point is required for INT16 tensors. As
+    // SingleOpModel::QuantizationParams calculates the scale on an asymmetric
+    // base [int_type::min, int_type::max], manually calculate the scale on a
+    // symmetric range [int_type::min+1, int_type::max] to ensure a null
+    // zero-point.
+    if (tensor.type == TensorType_INT16) {
+      CHECK_EQ(std::abs(tensor.min), tensor.max);
+      tensor.scale = tensor.max / std::numeric_limits<int16_t>::max();
+      tensor.zero_point = 0;
+      tensor.min = 0;
+      tensor.max = 0;
+    }
+    return tensor;
+  }
 
  protected:
   int input_;
@@ -255,6 +302,70 @@ TYPED_TEST(StablehloBatchNormTrainingTestFloat,
       model.GetBatchVar<Float>(),
       ElementsAreArray(ArrayFloatNear(
           {static_cast<Float>(13.560), static_cast<Float>(57.780)}, 0.1)));
+}
+
+// for quantized, the error shouldn't exceed step
+template <typename T>
+float GetTolerance(float min, float max) {
+  float kQuantizedStep =
+      2.0 * (max - min) /
+      (std::numeric_limits<T>::max() - std::numeric_limits<T>::min());
+  return kQuantizedStep;
+}
+
+template <typename Int>
+class StablehloBatchNormTrainingTestInt : public ::testing::Test {
+ public:
+  using IntType = Int;
+};
+
+using IntTestTypes = ::testing::Types<int8_t, int16_t>;
+
+TYPED_TEST_SUITE(StablehloBatchNormTrainingTestInt, IntTestTypes);
+
+TYPED_TEST(StablehloBatchNormTrainingTestInt,
+           StablehloBatchNormTrainingQuantizedTest) {
+  using Int = typename TestFixture::IntType;
+  TfLiteStablehloBatchNormTrainingParams params = {0.0 /*epsilon*/,
+                                                   2 /*feature_index*/};
+  float kArithmeticQuantizedTolerance = GetTolerance<Int>(-60.0f, 60.0f);
+  const float kQuantizedStep = 2.0 / 255.0;
+  const float kMulQuantizedTolerance =
+    2.0 * kQuantizedStep + kQuantizedStep * kQuantizedStep;
+  float kQuantizedTolerance = 4*kArithmeticQuantizedTolerance + kMulQuantizedTolerance;
+  StablehloBatchNormTrainingOpModel model(
+      {GetTTEnum<Int>(), {2, 2, 2}, -60.0f, 60.0f},
+      {GetTTEnum<Int>(), {2}, -60.0f, 60.0f},
+      {GetTTEnum<Int>(), {2}, -60.0f, 60.0f},
+      {GetTTEnum<Int>(), {}, -60.0f, 60.0f},
+      {GetTTEnum<Int>(), {}, -60.0f, 60.0f},
+      {GetTTEnum<Int>(), {}, -60.0f, 60.0f}, params);
+  model.QuantizeAndPopulate<Int>(
+      model.input(), {static_cast<float>(1.0), static_cast<float>(-2.0),
+                      static_cast<float>(3.0), static_cast<float>(-4.0),
+                      static_cast<float>(3.0), static_cast<float>(-4.0),
+                      static_cast<float>(-1.0), static_cast<float>(2.0)});
+  model.QuantizeAndPopulate<Int>(
+      model.scale(), {static_cast<float>(1.0), static_cast<float>(1.0)});
+  model.QuantizeAndPopulate<Int>(
+      model.offset(), {static_cast<float>(1.0), static_cast<float>(1.0)});
+
+  ASSERT_EQ(model.Invoke(), kTfLiteOk);
+  EXPECT_THAT(model.GetDequantizedOutput<Int>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<float>(0.69), static_cast<float>(1.0),
+                   static_cast<float>(1.90), static_cast<float>(0.18),
+                   static_cast<float>(1.90), static_cast<float>(0.18),
+                   static_cast<float>(-0.5), static_cast<float>(2.63)},
+                  kQuantizedTolerance)));
+  EXPECT_THAT(model.GetDequantizedBatchMean<Int>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<float>(1.5), static_cast<float>(-2.0)},
+                  kQuantizedTolerance)));
+  EXPECT_THAT(model.GetDequantizedBatchVar<Int>(),
+              ElementsAreArray(ArrayFloatNear(
+                  {static_cast<float>(2.75), static_cast<float>(6.0)},
+                  kQuantizedTolerance)));
 }
 
 }  // namespace

--- a/tensorflow/lite/kernels/test_util.h
+++ b/tensorflow/lite/kernels/test_util.h
@@ -108,6 +108,11 @@ constexpr TfLiteType typeToTfLiteType<Eigen::half>() {
   return kTfLiteFloat16;
 }
 
+template <>
+constexpr TfLiteType typeToTfLiteType<Eigen::bfloat16>() {
+  return kTfLiteBFloat16;
+}
+
 // A test model that contains a single operator. All operator inputs and
 // output are external to the model, so the tests can directly access them.
 // Typical usage:


### PR DESCRIPTION
 -Adds Stablehlo Batch Norm Training Implementation
 -Adds Stablehlo Batch Norm Training Unit Tests
 - `ComputeMean` and `ComputeVariance` functions have been moved to stablehlo_batch_norm_training.h in this commit